### PR TITLE
Updates to obsolete terms

### DIFF
--- a/src/ontology/wbphenotype-edit.owl
+++ b/src/ontology/wbphenotype-edit.owl
@@ -3664,6 +3664,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000107> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000108> (obsolete severe dumpy)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000108> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000108> <http://purl.obolibrary.org/obo/WBPhenotype_0000583>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000108> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000108> "WBPhenotype:0000108"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000108> "obsolete severe dumpy"^^xsd:string)
@@ -3672,6 +3673,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000109> (obsolete moderate dumpy)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000109> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000109> <http://purl.obolibrary.org/obo/WBPhenotype_0000583>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000109> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000109> "WBPhenotype:0000109"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000109> "obsolete moderate dumpy"^^xsd:string)
@@ -3680,6 +3682,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000110> (obsolete slightly dumpy)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000110> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000110> <http://purl.obolibrary.org/obo/WBPhenotype_0000583>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000110> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000110> "WBPhenotype:0000110"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000110> "obsolete slightly dumpy"^^xsd:string)
@@ -4926,6 +4929,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000247> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000248> (obsolete sensory neuroanatomy variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> <http://purl.obolibrary.org/obo/WBPhenotype_0000652>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> "sensory neuroanatomy abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000248> "WBPhenotype:0000248"^^xsd:string)
@@ -5136,8 +5141,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000270> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000271> (obsolete cell cycle slow)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> "OBSOLETE."^^xsd:string)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> <http://purl.obolibrary.org/obo/IAO_0000227>)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> <http://purl.obolibrary.org/obo/WBPhenotype_0000229>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> <http://purl.obolibrary.org/obo/WBPhenotype_0000318>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> <http://purl.obolibrary.org/obo/WBPhenotype_0001995>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000271> "WBPhenotype:0000271"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000271> "obsolete cell cycle slow"^^xsd:string)
@@ -5275,6 +5280,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000286> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000287> (obsolete vulval invagination L4 abnormal)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000287> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000287> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000287> <http://purl.obolibrary.org/obo/WBPhenotype_0000510>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000287> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000287> "WBPhenotype:0000287"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000287> "obsolete vulval invagination L4 abnormal"^^xsd:string)
@@ -5815,8 +5822,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000347> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000348> (obsolete muscle activation defective)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> "OBSOLETE."^^xsd:string)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> <http://purl.obolibrary.org/obo/IAO_0000227>)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> <http://purl.obolibrary.org/obo/WBPhenotype_0000319>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> <http://purl.obolibrary.org/obo/WBPhenotype_0001735>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000348> "WBPhenotype:0000348"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000348> "obsolete muscle activation defective"^^xsd:string)
@@ -7244,6 +7250,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000509> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000510> (vulval invagination variant L4)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00001738"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000510> "The characteristic Christmas-tree shaped invagination formed by the terminal vulval cells at the mid-late L4 stage is altered."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0000510> "WBPhenotype:0000287"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000510> "vulval invagination L4 abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000510> "vulval invagination abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000510> "C_elegans_phenotype_ontology"^^xsd:string)
@@ -7837,6 +7844,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000572> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000573> (obsolete neuronal branching variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> <http://purl.obolibrary.org/obo/WBPhenotype_0000633>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> <http://purl.obolibrary.org/obo/WBPhenotype_0001398>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> "neuronal branching abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000573> "WBPhenotype:0000573"^^xsd:string)
@@ -7973,6 +7982,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000586> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000587> (obsolete lectin staining variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000587> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000587> <http://purl.obolibrary.org/obo/WBPhenotype_0002072>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000587> "lectin staining abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000587> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000587> "WBPhenotype:0000587"^^xsd:string)
@@ -7985,6 +7995,7 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "no male abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "WBPhenotype:0000588"^^xsd:string)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "This phenotype was intended to reflect a lack of any phenotypic abnormality in the individuals in question. The C. elegans phenotype ontology no longer has terms specifically used to assert negation of a phenotype."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "obsolete no male variantity scored"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0000588> "true"^^xsd:boolean)
 
@@ -7994,6 +8005,7 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "no hermaphrodite abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "WBPhenotype:0000589"^^xsd:string)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "This phenotype was intended to reflect a lack of any phenotypic abnormality in the individuals in question. The C. elegans phenotype ontology no longer has terms specifically used to assert negation of a phenotype."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "obsolete no hermaphrodite variantity scored"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0000589> "true"^^xsd:boolean)
 
@@ -8621,6 +8633,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000651> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000652> (sensory system variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000652> "Variations in the progression of a set of interacting or interdependent entities forming the sensory system over time from an initial condition to a later condition compared to control animals. The sensory system is involved in the perception of a stimuli, its conversion into a signal and the recognition and characterization of the resulting signal."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0000652> "WBPhenotype:0000248"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000652> "sensory system abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000652> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000652> "WBPhenotype:0000652"^^xsd:string)
@@ -8873,6 +8886,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000677> <http://purl.obo
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "OBSOLETE."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "WBPhenotype:0000678"^^xsd:string)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "This phenotype was intended to reflect a lack of any phenotypic abnormality in the individuals in question. The C. elegans phenotype ontology no longer has terms specifically used to assert negation of a phenotype."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "obsolete no copper sensitivity"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0000678> "true"^^xsd:boolean)
 
@@ -9273,6 +9287,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000718> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000719> (obsolete reporter gene expression variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> <http://purl.obolibrary.org/obo/WBPhenotype_0000306>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> <http://purl.obolibrary.org/obo/WBPhenotype_0000717>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> "reporter gene expression abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000719> "WBPhenotype:0000719"^^xsd:string)
@@ -9282,6 +9298,8 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000720> (obsolete pattern of reporter gene expression variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> <http://purl.obolibrary.org/obo/WBPhenotype_0000111>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> <http://purl.obolibrary.org/obo/WBPhenotype_0000961>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> "pattern of reporter gene expression abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000720> "WBPhenotype:0000720"^^xsd:string)
@@ -9291,7 +9309,8 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000721> (obsolete level of reporter gene expression variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "OBSOLETE."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "level of reporter gene expression abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> <http://purl.obolibrary.org/obo/WBPhenotype_0000962>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "level of reporter gene expression abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "WBPhenotype:0000721"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000721> "obsolete level of reporter gene expression variant"^^xsd:string)
@@ -10615,8 +10634,11 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000860> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000861> (body wall muscle development variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "Any variation in the progression of the principal muscle cell type whose contractile activity generates body motion in the nematode over time compared to control. In C. elegans they consist of 95 unfused cells in the adult organized into four muscle quadrants. Their sarcomeres are obliquely striated and lie lengthwise along the body wall (Wormatlas)."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "body wall muscle development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "body wall muscle development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "body wall muscle cell development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "body wall muscle cell development variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "C_elegans_phenotype_ontology"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "muscle belly development abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "somatic muscle development abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "striated muscle development abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000861> "WBPhenotype:0000861"^^xsd:string)
@@ -10683,6 +10705,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000868> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000869> (obsolete mitochondria morphology variant muscle)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000869> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000869> <http://purl.obolibrary.org/obo/WBPhenotype_0001401>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000869> "mitochondria morphology abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000869> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000869> "WBPhenotype:0000869"^^xsd:string)
@@ -10692,6 +10715,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000870> (obsolete mitochondria morphology variant epithelial)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000870> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000870> <http://purl.obolibrary.org/obo/WBPhenotype_0001401>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000870> "mitochondria morphology abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000870> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000870> "WBPhenotype:0000870"^^xsd:string)
@@ -10701,6 +10725,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000871> (obsolete connected mitochondria epithelial)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000871> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000871> <http://purl.obolibrary.org/obo/WBPhenotype_0001402>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000871> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000871> "WBPhenotype:0000871"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000871> "obsolete connected mitochondria epithelial"^^xsd:string)
@@ -10709,6 +10734,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000872> (obsolete connected mitochodria muscle)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000872> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0000872> <http://purl.obolibrary.org/obo/WBPhenotype_0001402>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000872> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000872> "WBPhenotype:0000872"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000872> "obsolete connected mitochodria muscle"^^xsd:string)
@@ -11162,9 +11188,9 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000919> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000920> (obsolete body wall muscle cell development variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "OBSOLETE."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "body wall muscle cell development abnormal"^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> <http://purl.obolibrary.org/obo/WBPhenotype_0000861>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "C_elegans_phenotype_ontology"^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "muscle belly development abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "WBPhenotype:0000920"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "obsolete body wall muscle cell development variant"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0000920> "true"^^xsd:boolean)
@@ -11585,13 +11611,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000966> "germline mortal"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000966> <http://purl.obolibrary.org/obo/WBPhenotype_0000987>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000967> (obsolete male distal tip cell behavior abnormal)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000967> (obsolete male tail spike)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0000967> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0000967> <http://purl.obolibrary.org/obo/WBPhenotype_0001431>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "WBPhenotype:0000967"^^xsd:string)
-AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "In a WS193 version of the worm phenotype ontology OBO file, WBPhenotype:0000967 has term name \"male tail spike\"; In \"dump_phenotype_ace.pl\" script, WBPhenotype:0000967 has term name \"male distal tip cell behavior abnormal\""^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "obsolete male distal tip cell behavior abnormal"^^xsd:string)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "In the WS193 and WS200 versions of WormBase WBPhenotype:0000967 has term name \"male tail spike\"; In some older records the term ID WBPhenotype:0000967 had the term name \"male distal tip cell behavior abnormal\", which may reflect an earlier (now deprecated) usage of the term ID."^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "obsolete male tail spike"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0000967> "true"^^xsd:boolean)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000968> (tail spike variant)
@@ -12766,6 +12794,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001093> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001094> (obsolete NaCl response variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:cab"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001094> "OBSOLETE. Organismal response to NaCl differs from control animals."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0001094> <http://purl.obolibrary.org/obo/WBPhenotype_0000523>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001094> "NaCl response abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001094> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001094> "WBPhenotype:0001094"^^xsd:string)
@@ -13294,6 +13323,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001148> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001149> (obsolete polar body reabsorbed first early emb)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001149> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0001149> <http://purl.obolibrary.org/obo/WBPhenotype_0001148>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001149> "Emb"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001149> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001149> "WBPhenotype:0001149"^^xsd:string)
@@ -13588,6 +13618,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "WT"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "WBPhenotype:0001179"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "The phenotype ontology was restructured such that \"Abnormal\" is now the root term.  The term \"Abnormal\" with a \"Not\" qualifier is a suggested replacement for this term."^^xsd:string)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "This phenotype was intended to reflect a lack of any phenotypic abnormality in the individuals in question. The C. elegans phenotype ontology no longer has terms specifically used to assert negation of a phenotype."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "obsolete No variantity scored"^^xsd:string)
 AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0001179> "true"^^xsd:boolean)
 
@@ -13900,6 +13931,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001213> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001214> (obsolete metaphase to anaphase transition fails)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001214> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0001214> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0001214> <http://purl.obolibrary.org/obo/WBPhenotype_0001496>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001214> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001214> "WBPhenotype:0001214"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001214> "obsolete metaphase to anaphase transition fails"^^xsd:string)
@@ -14551,6 +14584,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001287> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001288> (<http://purl.obolibrary.org/obo/WBPhenotype_0001288>)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001288> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0001288> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0001288> <http://purl.obolibrary.org/obo/WBPhenotype_0001213>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001288> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001288> "WBPhenotype:0001288"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0001288> "is alternative id for \"locomotion reduced\" (WBPhenotype:0001213); may have originally had term name \"movement reduced\""^^xsd:string)
@@ -15547,7 +15582,9 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001400> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001401> (mitochondria morphology variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:cab"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "The morphological appearance of mitochondria is varied compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "mitochondria morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "mitochondria morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "mitochondria morphology variant epithelial"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "mitochondria morphology variant muscle"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "WBPhenotype:0001401"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001401> "mitochondria morphology variant"^^xsd:string)
@@ -15556,6 +15593,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001401> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001402> (connected mitochondria)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0007006"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00032231"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "Mitochondria are interconnected by thin tubules of mitochondrial inner or outer membrane."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "connected mitochodria muscle")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "connected mitochondria epithelial")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "WBPhenotype:0001402"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001402> "connected mitochondria"^^xsd:string)
@@ -16290,8 +16329,10 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001481> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001482> (frequency body bend reduced)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00024949"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "Animals exhibit a reduction in the frequency of oscillations between adjacent body segments from that observed for control animals."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "WBPhenotype:0002330"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "bending frequency reduced"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "frequency of sinusoidal movement reduced"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "temporal frequency of sinusoidal movement decreased"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "WBPhenotype:0001482"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001482> "frequency body bend reduced"^^xsd:string)
@@ -16424,6 +16465,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001495> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001496> (metaphase to anaphase transition defect)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0007091"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "Cells exhibit variations in the process whereby a cell progresses from metaphase to anaphase, compared to control. Metaphase is the second stage of chromosome segregation in the cell cycle where chromosomes become aligned on the equatorial plate of the cell and anaphase is the stage where sister chromatids (or homologous chromosomes) separate and migrate towards the poles of the spindle."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "WBPhenotype:0001214"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "metaphase to anaphase transition fails")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "Mat"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001496> "WBPhenotype:0001496"^^xsd:string)
@@ -17007,6 +17050,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001559> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001560> (obsolete dauer sensory system plug variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001560> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#consider> <http://purl.obolibrary.org/obo/WBPhenotype_0001560> <http://purl.obolibrary.org/obo/WBPhenotype_0001550>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001560> "dauer sensory system plug abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001560> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001560> "WBPhenotype:0001560"^^xsd:string)
@@ -20098,6 +20142,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001908> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001909> (obsolete translational repression variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001909> "OBSOLETE. Any variation in the prevention of mRNA translation that normally occurs in certain cells, compared to control."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0001909> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0001909> <http://purl.obolibrary.org/obo/WBPhenotype_0002157>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001909> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001909> "WBPhenotype:0001909"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001909> "obsolete translational repression variant"^^xsd:string)
@@ -22174,6 +22220,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002156> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002157> (translation repression variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00032489"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "The extent of translational repression varies from controls."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "WBPhenotype:0001909"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "translational repression variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "WBPhenotype:0002157"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002157> "translation repression variant"^^xsd:string)
@@ -23598,6 +23646,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002328> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002329> (obsolete temporal frequency of sinusoidal movement variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00043908"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002329> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000231> <http://purl.obolibrary.org/obo/WBPhenotype_0002329> <http://purl.obolibrary.org/obo/IAO_0000227>)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0002329> <http://purl.obolibrary.org/obo/WBPhenotype_0004023>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002329> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002329> "WBPhenotype:0002329"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002329> "obsolete temporal frequency of sinusoidal movement variant"^^xsd:string)
@@ -23606,6 +23656,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002330> (obsolete temporal frequency of sinusoidal movement decreased)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00043908"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002330> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0002330> <http://purl.obolibrary.org/obo/WBPhenotype_0001482>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002330> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002330> "WBPhenotype:0002330"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002330> "obsolete temporal frequency of sinusoidal movement decreased"^^xsd:string)
@@ -23614,6 +23665,7 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002331> (obsolete temporal frequency of sinusoidal movement increased)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00043908"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002331> "OBSOLETE."^^xsd:string)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/WBPhenotype_0002331> <http://purl.obolibrary.org/obo/WBPhenotype_0002348>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002331> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002331> "WBPhenotype:0002331"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002331> "obsolete temporal frequency of sinusoidal movement increased"^^xsd:string)
@@ -23750,7 +23802,9 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002347> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002348> (frequency of body bends increased)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00043908"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "Animals exhibit an increase in the frequency of oscillations between adjacent body segments from that observed for control animals."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "WBPhenotype:0002331"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "frequency of sinusoidal movement increased"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "temporal frequency of sinusoidal movement increased"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "WBPhenotype:0002348"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002348> "frequency of body bends increased"^^xsd:string)
@@ -25060,7 +25114,9 @@ SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0004022> <http://purl.obo
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004023> (frequency of body bend variant)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00024949"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "Animals exhibit variations in the frequency of oscillations between adjacent body segments from that observed for control animals."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "WBPhenotype:0002329"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "frequency of sinusoidal movement variant"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "temporal frequency of sinusoidal movement variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "bending frequency abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "frequency of body bend abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0004023> "C_elegans_phenotype_ontology"^^xsd:string)


### PR DESCRIPTION
Added replacement terms and 'consider' annotations to provide more information about alternatives for obsolete terms. Also added rdfs:comment for negation terms (e.g. 'No variantity scored')