### PR TITLE
Remove 'has_part some abnormal' EQ defs from axioms file

### DIFF
--- a/src/ontology/wbphenotype-equivalent-axioms-subq.owl
+++ b/src/ontology/wbphenotype-equivalent-axioms-subq.owl
@@ -1389,7 +1389,7 @@ Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/wbphenotype/wbphenoty
 #   Object Properties
 ############################
 
-# Object Property: <http://purl.obolibrary.org/obo/RO_0000052> (<http://purl.obolibrary.org/obo/RO_0000052>)
+# Object Property: <http://purl.obolibrary.org/obo/RO_0000052> (inheres in)
 
 SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/RO_0002314>)
 
@@ -1398,2227 +1398,2227 @@ SubObjectPropertyOf(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obo
 #   Classes
 ############################
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000005> (<http://purl.obolibrary.org/obo/WBPhenotype_0000005>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000005> (hyperactive egg laying)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000006> (<http://purl.obolibrary.org/obo/WBPhenotype_0000006>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000006> (egg laying defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000008> (<http://purl.obolibrary.org/obo/WBPhenotype_0000008>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000008> (anesthetic hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38867>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000009> (<http://purl.obolibrary.org/obo/WBPhenotype_0000009>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000009> (anesthetic resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000009> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38867>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000010> (<http://purl.obolibrary.org/obo/WBPhenotype_0000010>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000010> (drug hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000010> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000011> (<http://purl.obolibrary.org/obo/WBPhenotype_0000011>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000011> (drug resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000011> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_23888>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000013> (<http://purl.obolibrary.org/obo/WBPhenotype_0000013>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000013> (dauer defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043053>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000015> (<http://purl.obolibrary.org/obo/WBPhenotype_0000015>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000015> (positive chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000016> (<http://purl.obolibrary.org/obo/WBPhenotype_0000016>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000016> (aldicarb hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000017> (<http://purl.obolibrary.org/obo/WBPhenotype_0000017>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000017> (aldicarb resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000018> (<http://purl.obolibrary.org/obo/WBPhenotype_0000018>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000018> (pharyngeal pumping increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000019> (<http://purl.obolibrary.org/obo/WBPhenotype_0000019>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000019> (pharyngeal pumping reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000020> (<http://purl.obolibrary.org/obo/WBPhenotype_0000020>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000020> (pharyngeal pumping irregular)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000022> (<http://purl.obolibrary.org/obo/WBPhenotype_0000022>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000022> (long)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000022> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000023> (<http://purl.obolibrary.org/obo/WBPhenotype_0000023>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000023> (serotonin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000024> (<http://purl.obolibrary.org/obo/WBPhenotype_0000024>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000024> (serotonin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000025> (<http://purl.obolibrary.org/obo/WBPhenotype_0000025>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000025> (blistered)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001928> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000031> (<http://purl.obolibrary.org/obo/WBPhenotype_0000031>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000031> (slow growth)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040007>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000034> (<http://purl.obolibrary.org/obo/WBPhenotype_0000034>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000034> (embryonic polarity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001769> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBls_0000003>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000035> (<http://purl.obolibrary.org/obo/WBPhenotype_0000035>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000035> (larval body morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000035> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000036> (<http://purl.obolibrary.org/obo/WBPhenotype_0000036>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000036> (adult body morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000036> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000039> (<http://purl.obolibrary.org/obo/WBPhenotype_0000039>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000039> (life span variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000039> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000040> (<http://purl.obolibrary.org/obo/WBPhenotype_0000040>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000040> (one cell arrest early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000006>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000042> (<http://purl.obolibrary.org/obo/WBPhenotype_0000042>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000042> (slow embryonic development)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000043> (<http://purl.obolibrary.org/obo/WBPhenotype_0000043>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000043> (general pace of development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000044> (<http://purl.obolibrary.org/obo/WBPhenotype_0000044>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000044> (egg size defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000050> (<http://purl.obolibrary.org/obo/WBPhenotype_0000050>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000050> (embryonic lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000054> (<http://purl.obolibrary.org/obo/WBPhenotype_0000054>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000054> (larval lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000055> (<http://purl.obolibrary.org/obo/WBPhenotype_0000055>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000055> (early larval arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000055> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000027>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000024>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000056> (<http://purl.obolibrary.org/obo/WBPhenotype_0000056>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000056> (late larval arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000056> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000024>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000057> (<http://purl.obolibrary.org/obo/WBPhenotype_0000057>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000057> (early larval lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000057> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000027>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000024>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000058> (<http://purl.obolibrary.org/obo/WBPhenotype_0000058>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000058> (late larval lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000024>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000059> (<http://purl.obolibrary.org/obo/WBPhenotype_0000059>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000059> (larval arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000059> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000060> (<http://purl.obolibrary.org/obo/WBPhenotype_0000060>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000060> (adult lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000060> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000061> (<http://purl.obolibrary.org/obo/WBPhenotype_0000061>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000061> (extended life span)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001603> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000062> (<http://purl.obolibrary.org/obo/WBPhenotype_0000062>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000062> (lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000062> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000070> (<http://purl.obolibrary.org/obo/WBPhenotype_0000070>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000070> (male tail morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000075> (<http://purl.obolibrary.org/obo/WBPhenotype_0000075>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000075> (cuticle attachment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000075> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000079> (<http://purl.obolibrary.org/obo/WBPhenotype_0000079>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000079> (branched adult alae)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000079> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000081> (<http://purl.obolibrary.org/obo/WBPhenotype_0000081>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000081> (L1 arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000081> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000024>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000082> (<http://purl.obolibrary.org/obo/WBPhenotype_0000082>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000082> (L2 arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000082> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000083> (<http://purl.obolibrary.org/obo/WBPhenotype_0000083>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000083> (L3 arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000035>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000084> (<http://purl.obolibrary.org/obo/WBPhenotype_0000084>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000084> (L4 arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000038>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000085> (<http://purl.obolibrary.org/obo/WBPhenotype_0000085>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000085> (swollen intestine)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000085> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000086> (<http://purl.obolibrary.org/obo/WBPhenotype_0000086>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000086> (shrunken intestine)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000089> (<http://purl.obolibrary.org/obo/WBPhenotype_0000089>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000089> (alpha amanitin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_37415>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000090> (<http://purl.obolibrary.org/obo/WBPhenotype_0000090>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000090> (epidermis cuticle detached)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000090> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000091> (<http://purl.obolibrary.org/obo/WBPhenotype_0000091>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000091> (epidermis muscle detached)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000091> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000111> (<http://purl.obolibrary.org/obo/WBPhenotype_0000111>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000111> (pattern of gene expression variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000060> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000116> (<http://purl.obolibrary.org/obo/WBPhenotype_0000116>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000116> (mid larval lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000116> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000027>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000117> (<http://purl.obolibrary.org/obo/WBPhenotype_0000117>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000117> (L1 lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000024>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000118> (<http://purl.obolibrary.org/obo/WBPhenotype_0000118>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000118> (L2 lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000118> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000124> (<http://purl.obolibrary.org/obo/WBPhenotype_0000124>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000124> (enzyme activity reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000124> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000125> (<http://purl.obolibrary.org/obo/WBPhenotype_0000125>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000125> (enzyme activity increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000125> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000126> (<http://purl.obolibrary.org/obo/WBPhenotype_0000126>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000126> (general pace of development defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000126> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000134> (<http://purl.obolibrary.org/obo/WBPhenotype_0000134>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000134> (gene expression level reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010467>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000135> (<http://purl.obolibrary.org/obo/WBPhenotype_0000135>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000135> (gene expression level high)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000135> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010467>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000136> (<http://purl.obolibrary.org/obo/WBPhenotype_0000136>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000136> (mRNA levels increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009299>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000137> (<http://purl.obolibrary.org/obo/WBPhenotype_0000137>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000137> (mRNA levels reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009299>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000138> (<http://purl.obolibrary.org/obo/WBPhenotype_0000138>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000138> (lipid composition variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_35366>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000145> (<http://purl.obolibrary.org/obo/WBPhenotype_0000145>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000145> (fertility variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000145> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000155> (<http://purl.obolibrary.org/obo/WBPhenotype_0000155>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000155> (cell polarity reversed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000155> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000625> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007163>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000161> (<http://purl.obolibrary.org/obo/WBPhenotype_0000161>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000161> (nuclear rotation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000162> (<http://purl.obolibrary.org/obo/WBPhenotype_0000162>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000162> (pale larva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000162> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000328> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000163> (<http://purl.obolibrary.org/obo/WBPhenotype_0000163>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000163> (clear larva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000964> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000164> (<http://purl.obolibrary.org/obo/WBPhenotype_0000164>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000164> (thin)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000592> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000165> (<http://purl.obolibrary.org/obo/WBPhenotype_0000165>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000165> (cell fusion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000768>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000170> (<http://purl.obolibrary.org/obo/WBPhenotype_0000170>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000170> (precocious alae)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000170> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001754> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000172> (<http://purl.obolibrary.org/obo/WBPhenotype_0000172>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000172> (cell proliferation increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008283>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000173> (<http://purl.obolibrary.org/obo/WBPhenotype_0000173>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000173> (cell proliferation reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000173> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008283>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000177> (<http://purl.obolibrary.org/obo/WBPhenotype_0000177>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000177> (acetylcholinesterase reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000177> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003990>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000178> (<http://purl.obolibrary.org/obo/WBPhenotype_0000178>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000178> (cell degeneration)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000639> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000000>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000179> (<http://purl.obolibrary.org/obo/WBPhenotype_0000179>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000179> (neuron degeneration)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000179> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000639> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000181> (<http://purl.obolibrary.org/obo/WBPhenotype_0000181>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000181> (axon trajectory variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000181> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030424>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000182> (<http://purl.obolibrary.org/obo/WBPhenotype_0000182>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000182> (apoptosis reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000183> (<http://purl.obolibrary.org/obo/WBPhenotype_0000183>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000183> (apoptosis increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000184> (<http://purl.obolibrary.org/obo/WBPhenotype_0000184>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000184> (apoptosis fails to occur)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008219>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000185> (<http://purl.obolibrary.org/obo/WBPhenotype_0000185>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000185> (apoptosis protracted)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000185> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008219>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000187> (<http://purl.obolibrary.org/obo/WBPhenotype_0000187>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000187> (egg round)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000189> (<http://purl.obolibrary.org/obo/WBPhenotype_0000189>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000189> (hypodermis disorganized)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000190> (<http://purl.obolibrary.org/obo/WBPhenotype_0000190>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000190> (no dauer recovery)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0043053>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000192> (<http://purl.obolibrary.org/obo/WBPhenotype_0000192>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000192> (constitutive enzyme activity)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000214> (<http://purl.obolibrary.org/obo/WBPhenotype_0000214>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000214> (alpha amanitin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000214> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_37415>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000215> (<http://purl.obolibrary.org/obo/WBPhenotype_0000215>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000215> (no germ line)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005784>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000224> (<http://purl.obolibrary.org/obo/WBPhenotype_0000224>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000224> (serotonin deficient)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000224> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_28790>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000225> (<http://purl.obolibrary.org/obo/WBPhenotype_0000225>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000225> (serotonin synthesis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042427>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000226> (<http://purl.obolibrary.org/obo/WBPhenotype_0000226>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000226> (serotonin catabolism defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042429>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000229> (<http://purl.obolibrary.org/obo/WBPhenotype_0000229>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000229> (small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000229> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000230> (<http://purl.obolibrary.org/obo/WBPhenotype_0000230>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000230> (tail withered)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000234> (<http://purl.obolibrary.org/obo/WBPhenotype_0000234>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000234> (dopamine deficient)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000234> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_18243>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000235> (<http://purl.obolibrary.org/obo/WBPhenotype_0000235>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000235> (dopamine synthesis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000235> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042416>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000236> (<http://purl.obolibrary.org/obo/WBPhenotype_0000236>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000236> (dopamine catabolism defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042420>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000237> (<http://purl.obolibrary.org/obo/WBPhenotype_0000237>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000237> (foraging hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035177>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000238> (<http://purl.obolibrary.org/obo/WBPhenotype_0000238>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000238> (foraging reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035177>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000244> (<http://purl.obolibrary.org/obo/WBPhenotype_0000244>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000244> (apoptotic arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007140>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000247> (<http://purl.obolibrary.org/obo/WBPhenotype_0000247>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000247> (sodium chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_26708>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000251> (<http://purl.obolibrary.org/obo/WBPhenotype_0000251>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000251> (octopamine deficient)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_17134>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000252> (<http://purl.obolibrary.org/obo/WBPhenotype_0000252>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000252> (caffeine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_27732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000253> (<http://purl.obolibrary.org/obo/WBPhenotype_0000253>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000253> (movement erratic)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000253> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000330> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007626>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000254> (<http://purl.obolibrary.org/obo/WBPhenotype_0000254>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000254> (chloride chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000254> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_17996>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000263> (<http://purl.obolibrary.org/obo/WBPhenotype_0000263>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000263> (axoneme short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000263> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000569> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005930>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000264> (<http://purl.obolibrary.org/obo/WBPhenotype_0000264>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000264> (cAMP chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_17489>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000272> (<http://purl.obolibrary.org/obo/WBPhenotype_0000272>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000272> (egg laying irregular)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000272> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000274> (<http://purl.obolibrary.org/obo/WBPhenotype_0000274>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000274> (dead eggs laid)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000277> (<http://purl.obolibrary.org/obo/WBPhenotype_0000277>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000277> (rhythm slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048511>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000279> (<http://purl.obolibrary.org/obo/WBPhenotype_0000279>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000279> (spicule insertion defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034609>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000280> (<http://purl.obolibrary.org/obo/WBPhenotype_0000280>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000280> (breaks in alae)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000280> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001444> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000284> (<http://purl.obolibrary.org/obo/WBPhenotype_0000284>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000284> (sperm transfer defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000284> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007320>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000285> (<http://purl.obolibrary.org/obo/WBPhenotype_0000285>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000285> (ray tips swollen)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000285> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000286> (<http://purl.obolibrary.org/obo/WBPhenotype_0000286>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000286> (embryo disorganized)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000286> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000290> (<http://purl.obolibrary.org/obo/WBPhenotype_0000290>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000290> (sperm absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006798>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000291> (<http://purl.obolibrary.org/obo/WBPhenotype_0000291>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000291> (no oocytes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CL_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000294> (<http://purl.obolibrary.org/obo/WBPhenotype_0000294>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000294> (intestine dark)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000294> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000327> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000296> (<http://purl.obolibrary.org/obo/WBPhenotype_0000296>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000296> (spicules crumpled)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001810> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005312>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000297> (<http://purl.obolibrary.org/obo/WBPhenotype_0000297>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000297> (rays fused)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006941>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000298> (<http://purl.obolibrary.org/obo/WBPhenotype_0000298>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000298> (rays displaced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000298> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001852> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000302> (<http://purl.obolibrary.org/obo/WBPhenotype_0000302>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000302> (benzaldehyde chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000302> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_22698>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000303> (<http://purl.obolibrary.org/obo/WBPhenotype_0000303>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000303> (diacetyl chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_16583>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000304> (<http://purl.obolibrary.org/obo/WBPhenotype_0000304>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000304> (isoamyl alcohol chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15837>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000310> (<http://purl.obolibrary.org/obo/WBPhenotype_0000310>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000310> (cilia absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006816>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000312> (<http://purl.obolibrary.org/obo/WBPhenotype_0000312>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000312> (dauer pheromone production defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042810>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000318> (<http://purl.obolibrary.org/obo/WBPhenotype_0000318>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000318> (cell cycle delayed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000318> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000319> (<http://purl.obolibrary.org/obo/WBPhenotype_0000319>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000319> (large)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000319> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000323> (<http://purl.obolibrary.org/obo/WBPhenotype_0000323>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000323> (head swollen)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000323> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000324> (<http://purl.obolibrary.org/obo/WBPhenotype_0000324>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000324> (short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000331> (<http://purl.obolibrary.org/obo/WBPhenotype_0000331>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000331> (inhibitors of na k atpase resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000331> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_472805>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000338> (<http://purl.obolibrary.org/obo/WBPhenotype_0000338>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000338> (tail swelling)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000338> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000340> (<http://purl.obolibrary.org/obo/WBPhenotype_0000340>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000340> (imipramine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_47499>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000341> (<http://purl.obolibrary.org/obo/WBPhenotype_0000341>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000341> (imipramine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000341> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000344> (<http://purl.obolibrary.org/obo/WBPhenotype_0000344>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000344> (cloacal structures protrude)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000344> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005774>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000350> (<http://purl.obolibrary.org/obo/WBPhenotype_0000350>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000350> (hermaphrodite tail spike variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006979>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000351> (<http://purl.obolibrary.org/obo/WBPhenotype_0000351>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000351> (failure to hatch)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035188>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000352> (<http://purl.obolibrary.org/obo/WBPhenotype_0000352>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000352> (backing uncoordinated)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000770> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043057>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000353> (<http://purl.obolibrary.org/obo/WBPhenotype_0000353>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000353> (backing increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000353> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043057>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000355> (<http://purl.obolibrary.org/obo/WBPhenotype_0000355>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000355> (HSN differentiation precocious)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000355> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030154>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0006830>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000356> (<http://purl.obolibrary.org/obo/WBPhenotype_0000356>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000356> (spermatogenesis delayed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000356> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007283>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000360> (<http://purl.obolibrary.org/obo/WBPhenotype_0000360>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000360> (cytoplasmic streaming defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000360> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016482>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000363> (<http://purl.obolibrary.org/obo/WBPhenotype_0000363>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000363> (cell division slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000370> (<http://purl.obolibrary.org/obo/WBPhenotype_0000370>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000370> (egg long)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000370> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000371> (<http://purl.obolibrary.org/obo/WBPhenotype_0000371>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000371> (cell division incomplete)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000371> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000373> (<http://purl.obolibrary.org/obo/WBPhenotype_0000373>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000373> (egg shape variable)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000373> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001930> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000378> (<http://purl.obolibrary.org/obo/WBPhenotype_0000378>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000378> (pharyngeal pumping shallow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000378> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001472> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000379> (<http://purl.obolibrary.org/obo/WBPhenotype_0000379>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000379> (head notched)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000379> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000381> (<http://purl.obolibrary.org/obo/WBPhenotype_0000381>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000381> (serotonin reuptake inhibitor resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000381> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0014076>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000383> (<http://purl.obolibrary.org/obo/WBPhenotype_0000383>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000383> (lipid synthesis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000383> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008610>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000385> (<http://purl.obolibrary.org/obo/WBPhenotype_0000385>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000385> (sperm excess)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000387> (<http://purl.obolibrary.org/obo/WBPhenotype_0000387>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000387> (sperm nonmotile)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000387> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000390> (<http://purl.obolibrary.org/obo/WBPhenotype_0000390>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000390> (spermatid activation defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000390> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007286>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000392> (<http://purl.obolibrary.org/obo/WBPhenotype_0000392>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000392> (intestinal fluorescence increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001926> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000393> (<http://purl.obolibrary.org/obo/WBPhenotype_0000393>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000393> (cell migration failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016477>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000395> (<http://purl.obolibrary.org/obo/WBPhenotype_0000395>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000395> (no differentiated gametes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000395> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0007289>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000401> (<http://purl.obolibrary.org/obo/WBPhenotype_0000401>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000401> (no uterus)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000401> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006760>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000404> (<http://purl.obolibrary.org/obo/WBPhenotype_0000404>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000404> (delayed hatching)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035188>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000405> (<http://purl.obolibrary.org/obo/WBPhenotype_0000405>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000405> (giant oocytes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006797>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000408> (<http://purl.obolibrary.org/obo/WBPhenotype_0000408>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000408> (dauer recovery inhibited)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000408> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043053>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000409> (<http://purl.obolibrary.org/obo/WBPhenotype_0000409>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000409> (organism morphology variable)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000409> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#has_quality> <http://purl.obolibrary.org/obo/PATO_0001227>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000411> (<http://purl.obolibrary.org/obo/WBPhenotype_0000411>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000411> (rod like larval lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/PATO_0001873>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000412> (<http://purl.obolibrary.org/obo/WBPhenotype_0000412>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000412> (octanol chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_37868>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000417> (<http://purl.obolibrary.org/obo/WBPhenotype_0000417>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000417> (cell division failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000418> (<http://purl.obolibrary.org/obo/WBPhenotype_0000418>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000418> (intestinal cell division failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000419> (<http://purl.obolibrary.org/obo/WBPhenotype_0000419>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000419> (L3 lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000035>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000427> (<http://purl.obolibrary.org/obo/WBPhenotype_0000427>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000427> (no cuticle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005755>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000428> (<http://purl.obolibrary.org/obo/WBPhenotype_0000428>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000428> (no adult cuticle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000428> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000438> (<http://purl.obolibrary.org/obo/WBPhenotype_0000438>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000438> (retarded heterochronic variations)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040034>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000439> (<http://purl.obolibrary.org/obo/WBPhenotype_0000439>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000439> (precocious heterochronic variations)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040034>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000440> (<http://purl.obolibrary.org/obo/WBPhenotype_0000440>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000440> (excretory canals long)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005775>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000441> (<http://purl.obolibrary.org/obo/WBPhenotype_0000441>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000441> (tail rounded)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000441> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000442> (<http://purl.obolibrary.org/obo/WBPhenotype_0000442>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000442> (larval development retarded)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000451> (<http://purl.obolibrary.org/obo/WBPhenotype_0000451>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000451> (head protrusion)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000454> (<http://purl.obolibrary.org/obo/WBPhenotype_0000454>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000454> (head twisted)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000454> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000456> (<http://purl.obolibrary.org/obo/WBPhenotype_0000456>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000456> (touch resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0001966>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000459> (<http://purl.obolibrary.org/obo/WBPhenotype_0000459>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000459> (pesticide response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_25944>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000460> (<http://purl.obolibrary.org/obo/WBPhenotype_0000460>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000460> (paraquat response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_34905>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000461> (<http://purl.obolibrary.org/obo/WBPhenotype_0000461>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000461> (paraquat resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000461> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_34905>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000462> (<http://purl.obolibrary.org/obo/WBPhenotype_0000462>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000462> (paraquat hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_34905>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000464> (<http://purl.obolibrary.org/obo/WBPhenotype_0000464>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000464> (oxygen response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000464> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_25805>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000473> (<http://purl.obolibrary.org/obo/WBPhenotype_0000473>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000473> (progressive paralysis)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000473> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#has_quality> <http://purl.obolibrary.org/obo/PATO_0001818>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000475> (<http://purl.obolibrary.org/obo/WBPhenotype_0000475>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000475> (muscle detached)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000475> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000476> (<http://purl.obolibrary.org/obo/WBPhenotype_0000476>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000476> (progressive muscle detachment)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#has_quality> <http://purl.obolibrary.org/obo/PATO_0001818>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000479> (<http://purl.obolibrary.org/obo/WBPhenotype_0000479>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000479> (egg pale)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000328> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000480> (<http://purl.obolibrary.org/obo/WBPhenotype_0000480>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000480> (pyrazine chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000480> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_30953>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000484> (<http://purl.obolibrary.org/obo/WBPhenotype_0000484>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000484> (embryo small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000484> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000486> (<http://purl.obolibrary.org/obo/WBPhenotype_0000486>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000486> (colchicine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000486> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_27882>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000487> (<http://purl.obolibrary.org/obo/WBPhenotype_0000487>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000487> (colchicine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000487> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_27882>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000490> (<http://purl.obolibrary.org/obo/WBPhenotype_0000490>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000490> (pharynx disorganized)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000491> (<http://purl.obolibrary.org/obo/WBPhenotype_0000491>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000491> (isthmus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000491> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003734>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000492> (<http://purl.obolibrary.org/obo/WBPhenotype_0000492>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000492> (corpus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003733>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000493> (<http://purl.obolibrary.org/obo/WBPhenotype_0000493>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000493> (metacorpus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003711>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000495> (<http://purl.obolibrary.org/obo/WBPhenotype_0000495>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000495> (ray ectopic)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000498> (<http://purl.obolibrary.org/obo/WBPhenotype_0000498>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000498> (methyl methanesulfonate response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_25255>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000499> (<http://purl.obolibrary.org/obo/WBPhenotype_0000499>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000499> (ethyl methanesulfonate response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_23994>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000500> (<http://purl.obolibrary.org/obo/WBPhenotype_0000500>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000500> (acetylcholinesterase inhibitor hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000507> (<http://purl.obolibrary.org/obo/WBPhenotype_0000507>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000507> (acetylcholine levels variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15355>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000508> (<http://purl.obolibrary.org/obo/WBPhenotype_0000508>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000508> (nonsense mRNA accumulation)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000508> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000184>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000516> (<http://purl.obolibrary.org/obo/WBPhenotype_0000516>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000516> (ventral cord disorganized)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005829>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (<http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (<http://purl.obolibrary.org/obo/WBPhenotype_0000536>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000000>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000546> (<http://purl.obolibrary.org/obo/WBPhenotype_0000546>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000546> (early eggs laid)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000546> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000548> (<http://purl.obolibrary.org/obo/WBPhenotype_0000548>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000548> (muscle dystrophy)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000548> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000549> (<http://purl.obolibrary.org/obo/WBPhenotype_0000549>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000549> (head muscle dystrophy)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000549> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006761>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000552> (<http://purl.obolibrary.org/obo/WBPhenotype_0000552>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000552> (GABA levels variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_16865>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000553> (<http://purl.obolibrary.org/obo/WBPhenotype_0000553>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000553> (muscle birefringence variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032982>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000559> (<http://purl.obolibrary.org/obo/WBPhenotype_0000559>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000559> (calcium channel modulator hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38808>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000560> (<http://purl.obolibrary.org/obo/WBPhenotype_0000560>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000560> (calcium channel modulator resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000560> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38808>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000574> (<http://purl.obolibrary.org/obo/WBPhenotype_0000574>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000574> (excretory canal short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005775>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (<http://purl.obolibrary.org/obo/WBPhenotype_0000575>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (organ system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005746>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (<http://purl.obolibrary.org/obo/WBPhenotype_0000576>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (organism physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000591> (<http://purl.obolibrary.org/obo/WBPhenotype_0000591>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000591> (metal response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000591> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_33521>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000592> (<http://purl.obolibrary.org/obo/WBPhenotype_0000592>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000592> (copper response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000592> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_30052>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000593> (<http://purl.obolibrary.org/obo/WBPhenotype_0000593>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000593> (copper hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000593> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_30052>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000606> (<http://purl.obolibrary.org/obo/WBPhenotype_0000606>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000606> (alimentary system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000607> (<http://purl.obolibrary.org/obo/WBPhenotype_0000607>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000607> (coelomic system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000607> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005749>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000608> (<http://purl.obolibrary.org/obo/WBPhenotype_0000608>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000608> (epithelial system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005730>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000609> (<http://purl.obolibrary.org/obo/WBPhenotype_0000609>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000609> (excretory secretory system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000610> (<http://purl.obolibrary.org/obo/WBPhenotype_0000610>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000610> (excretory system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005736>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000611> (<http://purl.obolibrary.org/obo/WBPhenotype_0000611>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000611> (muscle system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000612> (<http://purl.obolibrary.org/obo/WBPhenotype_0000612>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000612> (nervous system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005735>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000613> (<http://purl.obolibrary.org/obo/WBPhenotype_0000613>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000613> (reproductive system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000613> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005747>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000630> (<http://purl.obolibrary.org/obo/WBPhenotype_0000630>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000630> (quinine chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15854>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000642> (<http://purl.obolibrary.org/obo/WBPhenotype_0000642>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000642> (hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000643> (<http://purl.obolibrary.org/obo/WBPhenotype_0000643>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000643> (locomotion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000643> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000770> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000644> (<http://purl.obolibrary.org/obo/WBPhenotype_0000644>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000644> (paralyzed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000646> (<http://purl.obolibrary.org/obo/WBPhenotype_0000646>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000646> (sluggish)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000649> (<http://purl.obolibrary.org/obo/WBPhenotype_0000649>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000649> (vulva location variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000651> (<http://purl.obolibrary.org/obo/WBPhenotype_0000651>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000651> (constipated)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030421>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000660> (<http://purl.obolibrary.org/obo/WBPhenotype_0000660>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000660> (social feeding increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000660> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035176>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000661> (<http://purl.obolibrary.org/obo/WBPhenotype_0000661>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000661> (solitary feeding increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000661> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035176>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000667> (<http://purl.obolibrary.org/obo/WBPhenotype_0000667>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000667> (gonad displaced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000667> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001852> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005785>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000671> (<http://purl.obolibrary.org/obo/WBPhenotype_0000671>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000671> (resistant to copper)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_28694>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000673> (<http://purl.obolibrary.org/obo/WBPhenotype_0000673>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000673> (brood size variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000674> (<http://purl.obolibrary.org/obo/WBPhenotype_0000674>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000674> (slow development)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000674> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000675> (<http://purl.obolibrary.org/obo/WBPhenotype_0000675>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000675> (zygotic lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000675> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000365>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000676> (<http://purl.obolibrary.org/obo/WBPhenotype_0000676>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000676> (growth rate variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000676> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000680> (<http://purl.obolibrary.org/obo/WBPhenotype_0000680>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000680> (aldicarb response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000680> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000682> (<http://purl.obolibrary.org/obo/WBPhenotype_0000682>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000682> (feminization of germline)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000682> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000467> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040022>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000684> (<http://purl.obolibrary.org/obo/WBPhenotype_0000684>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000684> (fewer germ cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000586>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000688> (<http://purl.obolibrary.org/obo/WBPhenotype_0000688>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000688> (sterile)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000688> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000956> <http://purl.obolibrary.org/obo/PATO_0001767> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000692> (<http://purl.obolibrary.org/obo/WBPhenotype_0000692>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000692> (male sterile)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000692> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000956> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000694> (<http://purl.obolibrary.org/obo/WBPhenotype_0000694>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000694> (hermaphrodite sterile)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000956> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007849>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000696> (<http://purl.obolibrary.org/obo/WBPhenotype_0000696>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000696> (everted vulva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000696> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000697> (<http://purl.obolibrary.org/obo/WBPhenotype_0000697>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000697> (protruding vulva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000697> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000698> (<http://purl.obolibrary.org/obo/WBPhenotype_0000698>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000698> (vulvaless)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000700> (<http://purl.obolibrary.org/obo/WBPhenotype_0000700>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000700> (multivulva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000700> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000703> (<http://purl.obolibrary.org/obo/WBPhenotype_0000703>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000703> (epithelial morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000706> (<http://purl.obolibrary.org/obo/WBPhenotype_0000706>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000706> (gut granule biogenesis reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000706> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033363>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000707> (<http://purl.obolibrary.org/obo/WBPhenotype_0000707>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000707> (pharyngeal development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000707> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060465>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000715> (<http://purl.obolibrary.org/obo/WBPhenotype_0000715>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000715> (muscle excess)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000715> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000731> (<http://purl.obolibrary.org/obo/WBPhenotype_0000731>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000731> (germ cell hypersensitive ionizing radiation)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000731> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0006796>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000734> (<http://purl.obolibrary.org/obo/WBPhenotype_0000734>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000734> (hypodermal cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000734> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000737> (<http://purl.obolibrary.org/obo/WBPhenotype_0000737>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000737> (germ cell resistant ionizing radiation)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000737> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0006796>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000743> (<http://purl.obolibrary.org/obo/WBPhenotype_0000743>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000743> (RNAi response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000743> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0016246>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000760> (<http://purl.obolibrary.org/obo/WBPhenotype_0000760>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000760> (spindle orientation defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000760> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000762> (<http://purl.obolibrary.org/obo/WBPhenotype_0000762>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000762> (spindle position defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000762> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000763> (<http://purl.obolibrary.org/obo/WBPhenotype_0000763>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000763> (embryonic cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007028>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000768> (<http://purl.obolibrary.org/obo/WBPhenotype_0000768>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000768> (cytoplasmic structure defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000768> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000141> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000769> (<http://purl.obolibrary.org/obo/WBPhenotype_0000769>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000769> (cytoplasmic appearance defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000769> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000775> (<http://purl.obolibrary.org/obo/WBPhenotype_0000775>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000775> (meiosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000775> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000778> (<http://purl.obolibrary.org/obo/WBPhenotype_0000778>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000778> (feeding inefficient)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000778> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001677> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007631>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000783> (<http://purl.obolibrary.org/obo/WBPhenotype_0000783>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000783> (M line absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000783> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0031430>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005863>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000784> (<http://purl.obolibrary.org/obo/WBPhenotype_0000784>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000784> (male fertility variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000784> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000789> (<http://purl.obolibrary.org/obo/WBPhenotype_0000789>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000789> (fluoxetine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000789> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_5118>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000790> (<http://purl.obolibrary.org/obo/WBPhenotype_0000790>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000790> (fluoxetine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000790> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_5118>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0014076>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000803> (<http://purl.obolibrary.org/obo/WBPhenotype_0000803>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000803> (head development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000803> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060322>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000806> (<http://purl.obolibrary.org/obo/WBPhenotype_0000806>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000806> (hermaphrodite fertility variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000806> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007849>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000846> (<http://purl.obolibrary.org/obo/WBPhenotype_0000846>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000846> (presynaptic region physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000846> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048786>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000848> (<http://purl.obolibrary.org/obo/WBPhenotype_0000848>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000848> (developmental delay)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000848> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000849> (<http://purl.obolibrary.org/obo/WBPhenotype_0000849>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000849> (amphid physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000849> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005394>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000851> (<http://purl.obolibrary.org/obo/WBPhenotype_0000851>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000851> (ciliated neuron physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006816>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000854> (<http://purl.obolibrary.org/obo/WBPhenotype_0000854>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000854> (intraflagellar transport defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000854> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000863> (<http://purl.obolibrary.org/obo/WBPhenotype_0000863>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000863> (male fertility reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000863> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000865> (<http://purl.obolibrary.org/obo/WBPhenotype_0000865>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000865> (amphid sheath cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000865> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006754>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000867> (<http://purl.obolibrary.org/obo/WBPhenotype_0000867>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000867> (embryonic arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000867> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000868> (<http://purl.obolibrary.org/obo/WBPhenotype_0000868>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000868> (paralyzed body)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000868> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005738>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000881> (<http://purl.obolibrary.org/obo/WBPhenotype_0000881>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000881> (cilia mislocalized)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000881> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006816>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000891> (<http://purl.obolibrary.org/obo/WBPhenotype_0000891>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000891> (clear adult)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000891> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000964> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000915> (<http://purl.obolibrary.org/obo/WBPhenotype_0000915>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000915> (pale adult)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000915> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000328> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000928> (<http://purl.obolibrary.org/obo/WBPhenotype_0000928>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000928> (male physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000928> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000929> (<http://purl.obolibrary.org/obo/WBPhenotype_0000929>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000929> (hermaphrodite physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000929> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000057>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000931> (<http://purl.obolibrary.org/obo/WBPhenotype_0000931>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000931> (bis phenol A response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000931> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_33216>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042221>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000932> (<http://purl.obolibrary.org/obo/WBPhenotype_0000932>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000932> (bis phenol A hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000932> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_33216>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042221>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000934> (<http://purl.obolibrary.org/obo/WBPhenotype_0000934>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000934> (developmental morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000934> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000964> (<http://purl.obolibrary.org/obo/WBPhenotype_0000964>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000964> (DMPP resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000964> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_4290>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000966> (<http://purl.obolibrary.org/obo/WBPhenotype_0000966>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000966> (germline mortal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000966> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000586>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000973> (<http://purl.obolibrary.org/obo/WBPhenotype_0000973>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000973> (homologous recombination increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000973> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006310>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000974> (<http://purl.obolibrary.org/obo/WBPhenotype_0000974>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000974> (accessory cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000974> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005762>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000975> (<http://purl.obolibrary.org/obo/WBPhenotype_0000975>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000975> (neuronal sheath cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000975> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005811>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000976> (<http://purl.obolibrary.org/obo/WBPhenotype_0000976>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000976> (ventral cord patterning variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000976> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000060> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005829>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000978> (<http://purl.obolibrary.org/obo/WBPhenotype_0000978>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000978> (spermatheca physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005319>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000983> (<http://purl.obolibrary.org/obo/WBPhenotype_0000983>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000983> (fertilization defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000983> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009566>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (<http://purl.obolibrary.org/obo/WBPhenotype_0000985>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (blast cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000985> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005623>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000986> (<http://purl.obolibrary.org/obo/WBPhenotype_0000986>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000986> (epithelial cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000986> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000066>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000987> (<http://purl.obolibrary.org/obo/WBPhenotype_0000987>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000987> (germ cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000987> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000586>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000989> (<http://purl.obolibrary.org/obo/WBPhenotype_0000989>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000989> (marginal cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000989> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003673>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000990> (<http://purl.obolibrary.org/obo/WBPhenotype_0000990>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000990> (muscle cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000990> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000991> (<http://purl.obolibrary.org/obo/WBPhenotype_0000991>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000991> (neuron physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000991> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001003> (<http://purl.obolibrary.org/obo/WBPhenotype_0001003>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001003> (L4 lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000038>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001006> (<http://purl.obolibrary.org/obo/WBPhenotype_0001006>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001006> (pharyngeal pumping rate variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001017> (<http://purl.obolibrary.org/obo/WBPhenotype_0001017>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001017> (adult growth variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001019> (<http://purl.obolibrary.org/obo/WBPhenotype_0001019>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001019> (mid larval arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000027>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000027>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001020> (<http://purl.obolibrary.org/obo/WBPhenotype_0001020>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001020> (embryonic lethal late emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000021>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001026> (<http://purl.obolibrary.org/obo/WBPhenotype_0001026>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001026> (nuclear morphology variation early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001026> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001031> (<http://purl.obolibrary.org/obo/WBPhenotype_0001031>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001031> (pronuclear migration reduced early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001034> (<http://purl.obolibrary.org/obo/WBPhenotype_0001034>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001034> (pronuclear nuclear appearance defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001041> (<http://purl.obolibrary.org/obo/WBPhenotype_0001041>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001041> (meiosis defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001042> (<http://purl.obolibrary.org/obo/WBPhenotype_0001042>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001042> (neuron function reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001046> (<http://purl.obolibrary.org/obo/WBPhenotype_0001046>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001046> (pharyngeal muscle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005451>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001054> (<http://purl.obolibrary.org/obo/WBPhenotype_0001054>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001054> (cGMP chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_27682>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001055> (<http://purl.obolibrary.org/obo/WBPhenotype_0001055>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001055> (bromide chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001055> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15858>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001056> (<http://purl.obolibrary.org/obo/WBPhenotype_0001056>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001056> (iodide chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001056> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_16382>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001057> (<http://purl.obolibrary.org/obo/WBPhenotype_0001057>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001057> (lithium chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001057> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_30145>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001058> (<http://purl.obolibrary.org/obo/WBPhenotype_0001058>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001058> (potassium chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_26216>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001059> (<http://purl.obolibrary.org/obo/WBPhenotype_0001059>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001059> (magnesium chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001059> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_25107>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001068> (<http://purl.obolibrary.org/obo/WBPhenotype_0001068>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001068> (egg laying serotonin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001068> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001073> (<http://purl.obolibrary.org/obo/WBPhenotype_0001073>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001073> (egg laying response to food variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001073> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_33290>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001074> (<http://purl.obolibrary.org/obo/WBPhenotype_0001074>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001074> (vulval muscle unresponsive to serotonin)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001074> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000488> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005821>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001075> (<http://purl.obolibrary.org/obo/WBPhenotype_0001075>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001075> (vulval muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001075> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001081> (<http://purl.obolibrary.org/obo/WBPhenotype_0001081>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001081> (cytoplasmic morphology defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001081> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001084> (<http://purl.obolibrary.org/obo/WBPhenotype_0001084>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001084> (sodium chloride chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_26710>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001085> (<http://purl.obolibrary.org/obo/WBPhenotype_0001085>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001085> (butanone chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001085> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_22951>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001087> (<http://purl.obolibrary.org/obo/WBPhenotype_0001087>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001087> (acetone chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001087> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15347>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001088> (<http://purl.obolibrary.org/obo/WBPhenotype_0001088>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001088> (pentanol chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001088> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_16133>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001089> (<http://purl.obolibrary.org/obo/WBPhenotype_0001089>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001089> (hexanol chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_18099>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001093> (<http://purl.obolibrary.org/obo/WBPhenotype_0001093>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001093> (intestinal physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001093> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001098> (<http://purl.obolibrary.org/obo/WBPhenotype_0001098>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001098> (no rectum)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001098> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005773>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001100> (<http://purl.obolibrary.org/obo/WBPhenotype_0001100>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001100> (early embryonic lethal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001103> (<http://purl.obolibrary.org/obo/WBPhenotype_0001103>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001103> (spindle absent early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001104> (<http://purl.obolibrary.org/obo/WBPhenotype_0001104>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001104> (P0 spindle absent early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001104> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004422>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001105> (<http://purl.obolibrary.org/obo/WBPhenotype_0001105>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001105> (P0 spindle position defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001105> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0004422>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005819>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001106> (<http://purl.obolibrary.org/obo/WBPhenotype_0001106>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001106> (spindle orientation variant AB or P1 early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001107> (<http://purl.obolibrary.org/obo/WBPhenotype_0001107>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001107> (spindle rotation defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001107> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001118> (<http://purl.obolibrary.org/obo/WBPhenotype_0001118>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001118> (cell position defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001118> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000000>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001119> (<http://purl.obolibrary.org/obo/WBPhenotype_0001119>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001119> (cell cycle slow early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001119> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051726>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001129> (<http://purl.obolibrary.org/obo/WBPhenotype_0001129>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001129> (cleavage furrow defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001129> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0032154>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001130> (<http://purl.obolibrary.org/obo/WBPhenotype_0001130>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001130> (cytokinesis fails early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001130> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000910>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001135> (<http://purl.obolibrary.org/obo/WBPhenotype_0001135>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001135> (embryonic morphology defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001135> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001136> (<http://purl.obolibrary.org/obo/WBPhenotype_0001136>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001136> (embryonic morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001137> (<http://purl.obolibrary.org/obo/WBPhenotype_0001137>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001137> (embryos small early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001142> (<http://purl.obolibrary.org/obo/WBPhenotype_0001142>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001142> (nuclear number defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001143> (<http://purl.obolibrary.org/obo/WBPhenotype_0001143>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001143> (multiple nuclei early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001153> (<http://purl.obolibrary.org/obo/WBPhenotype_0001153>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001153> (pronuclear migration failure early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001153> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001156> (<http://purl.obolibrary.org/obo/WBPhenotype_0001156>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001156> (pronuclear size defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001156> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001159> (<http://purl.obolibrary.org/obo/WBPhenotype_0001159>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001159> (pronuclear morphology defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001159> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001162> (<http://purl.obolibrary.org/obo/WBPhenotype_0001162>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001162> (pronuclear number defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001162> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001164> (<http://purl.obolibrary.org/obo/WBPhenotype_0001164>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001164> (excess pronucleus early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001165> (<http://purl.obolibrary.org/obo/WBPhenotype_0001165>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001165> (excess maternal pronucleus early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001939>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001166> (<http://purl.obolibrary.org/obo/WBPhenotype_0001166>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001166> (excess paternal pronucleus variant centrosome early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001940>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001168> (<http://purl.obolibrary.org/obo/WBPhenotype_0001168>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001168> (pseudocleavage absent early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0030588>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001169> (<http://purl.obolibrary.org/obo/WBPhenotype_0001169>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001169> (pseudocleavage exaggerated early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001169> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030588>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001170> (<http://purl.obolibrary.org/obo/WBPhenotype_0001170>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001170> (sterile F0 48 hours post injection)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001170> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000956> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004422>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001171> (<http://purl.obolibrary.org/obo/WBPhenotype_0001171>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001171> (shortened life span)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001176> (<http://purl.obolibrary.org/obo/WBPhenotype_0001176>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001176> (one cell shape defective early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000006>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001182> (<http://purl.obolibrary.org/obo/WBPhenotype_0001182>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001182> (fat content variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_35366>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001183> (<http://purl.obolibrary.org/obo/WBPhenotype_0001183>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001183> (fat content reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_35366>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001184> (<http://purl.obolibrary.org/obo/WBPhenotype_0001184>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001184> (fat content increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001162> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_35366>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001190> (<http://purl.obolibrary.org/obo/WBPhenotype_0001190>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001190> (pharyngeal physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001191> (<http://purl.obolibrary.org/obo/WBPhenotype_0001191>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001191> (pharyngeal muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005451>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001194> (<http://purl.obolibrary.org/obo/WBPhenotype_0001194>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001194> (ectopic neuron)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001194> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001195> (<http://purl.obolibrary.org/obo/WBPhenotype_0001195>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001195> (generation calcium signal defective pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001195> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050848>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001196> (<http://purl.obolibrary.org/obo/WBPhenotype_0001196>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001196> (synchronization calcium signal defective pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000688> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0019722>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001197> (<http://purl.obolibrary.org/obo/WBPhenotype_0001197>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001197> (somatic gonad physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005785>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001198> (<http://purl.obolibrary.org/obo/WBPhenotype_0001198>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001198> (somatic sheath physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001198> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005828>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001202> (<http://purl.obolibrary.org/obo/WBPhenotype_0001202>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001202> (nicotine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001202> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_18723>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001203> (<http://purl.obolibrary.org/obo/WBPhenotype_0001203>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001203> (nicotine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001203> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_17688>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001208> (<http://purl.obolibrary.org/obo/WBPhenotype_0001208>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001208> (RNAi resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (<http://purl.obolibrary.org/obo/WBPhenotype_0001210>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (pericellular component physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001212> (<http://purl.obolibrary.org/obo/WBPhenotype_0001212>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001212> (cuticle fragile)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001212> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001213> (<http://purl.obolibrary.org/obo/WBPhenotype_0001213>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001213> (locomotion reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007626>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001216> (<http://purl.obolibrary.org/obo/WBPhenotype_0001216>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001216> (meiosis metaphase to anaphase transition block)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001216> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033316>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001225> (<http://purl.obolibrary.org/obo/WBPhenotype_0001225>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001225> (phasmid socket absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0004112>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001228> (<http://purl.obolibrary.org/obo/WBPhenotype_0001228>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001228> (alae absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001229> (<http://purl.obolibrary.org/obo/WBPhenotype_0001229>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001229> (anterior neuron migration defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001229> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0001764>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001230> (<http://purl.obolibrary.org/obo/WBPhenotype_0001230>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001230> (anterior cell migration defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016477>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001231> (<http://purl.obolibrary.org/obo/WBPhenotype_0001231>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001231> (intraflagellar transport accelerated)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001232> (<http://purl.obolibrary.org/obo/WBPhenotype_0001232>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001232> (serotonin response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001232> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001234> (<http://purl.obolibrary.org/obo/WBPhenotype_0001234>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001234> (nonanone chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001234> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_25579>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001235> (<http://purl.obolibrary.org/obo/WBPhenotype_0001235>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001235> (cell division polarity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001235> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001769> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001237> (<http://purl.obolibrary.org/obo/WBPhenotype_0001237>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001237> (ectopic axon outgrowth)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048846>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001238> (<http://purl.obolibrary.org/obo/WBPhenotype_0001238>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001238> (male mating latency variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007618>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001242> (<http://purl.obolibrary.org/obo/WBPhenotype_0001242>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001242> (intraflagellar transport slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001243> (<http://purl.obolibrary.org/obo/WBPhenotype_0001243>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001243> (intraflagellar transport distance short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001243> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000375> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001244> (<http://purl.obolibrary.org/obo/WBPhenotype_0001244>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001244> (intraflagellar transport absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0042073>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001247> (<http://purl.obolibrary.org/obo/WBPhenotype_0001247>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001247> (anterograde transport defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048490>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001258> (<http://purl.obolibrary.org/obo/WBPhenotype_0001258>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001258> (RNAi enhanced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001262> (<http://purl.obolibrary.org/obo/WBPhenotype_0001262>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001262> (vulval development incomplete)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040025>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001264> (<http://purl.obolibrary.org/obo/WBPhenotype_0001264>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001264> (peroxisome physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005777>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001281> (<http://purl.obolibrary.org/obo/WBPhenotype_0001281>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001281> (stuffed pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001836> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001289> (<http://purl.obolibrary.org/obo/WBPhenotype_0001289>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001289> (acetylcholinesterase inhibitor resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001290> (<http://purl.obolibrary.org/obo/WBPhenotype_0001290>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001290> (acetylcholinesterase inhibitor response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001292> (<http://purl.obolibrary.org/obo/WBPhenotype_0001292>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001292> (body wall muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006804>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001293> (<http://purl.obolibrary.org/obo/WBPhenotype_0001293>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001293> (larval physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000023>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001294> (<http://purl.obolibrary.org/obo/WBPhenotype_0001294>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001294> (head bent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001294> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001296> (<http://purl.obolibrary.org/obo/WBPhenotype_0001296>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001296> (lannate resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_6835>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001300> (<http://purl.obolibrary.org/obo/WBPhenotype_0001300>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001300> (germ cell cytoplasmic morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0005737> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000586>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001303> (<http://purl.obolibrary.org/obo/WBPhenotype_0001303>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001303> (ectopic cell)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000000>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001306> (<http://purl.obolibrary.org/obo/WBPhenotype_0001306>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001306> (male reproductive system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001306> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005747>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001310> (<http://purl.obolibrary.org/obo/WBPhenotype_0001310>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001310> (neuron positioning variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001312> (<http://purl.obolibrary.org/obo/WBPhenotype_0001312>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001312> (neuron number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001313> (<http://purl.obolibrary.org/obo/WBPhenotype_0001313>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001313> (uterine muscle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001313> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005342>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001314> (<http://purl.obolibrary.org/obo/WBPhenotype_0001314>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001314> (vulval muscle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001314> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001322> (<http://purl.obolibrary.org/obo/WBPhenotype_0001322>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001322> (vesicle number reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001322> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031982>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001325> (<http://purl.obolibrary.org/obo/WBPhenotype_0001325>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001325> (backing not sustained)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001570> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0043057>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001327> (<http://purl.obolibrary.org/obo/WBPhenotype_0001327>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001327> (cell gamma ray hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001327> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001330> (<http://purl.obolibrary.org/obo/WBPhenotype_0001330>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001330> (egg laying event infrequent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001330> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000381> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001332> (<http://purl.obolibrary.org/obo/WBPhenotype_0001332>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001332> (vesicle number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001332> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031982>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001335> (<http://purl.obolibrary.org/obo/WBPhenotype_0001335>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001335> (hermaphrodite reproductive system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001335> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005747>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007849>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001337> (<http://purl.obolibrary.org/obo/WBPhenotype_0001337>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001337> (adrenergic receptor antagonist response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_37887>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001340> (<http://purl.obolibrary.org/obo/WBPhenotype_0001340>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001340> (egg laying imipramine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001342> (<http://purl.obolibrary.org/obo/WBPhenotype_0001342>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001342> (egg laying imipramine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001350> (<http://purl.obolibrary.org/obo/WBPhenotype_0001350>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001350> (protein phosphorylation increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006468>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001351> (<http://purl.obolibrary.org/obo/WBPhenotype_0001351>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001351> (protein phosphorylation reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006468>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001358> (<http://purl.obolibrary.org/obo/WBPhenotype_0001358>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001358> (male nervous system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001358> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005735>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001362> (<http://purl.obolibrary.org/obo/WBPhenotype_0001362>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001362> (chromosome condensation failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030261>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001363> (<http://purl.obolibrary.org/obo/WBPhenotype_0001363>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001363> (head cavity)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002112> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001368> (<http://purl.obolibrary.org/obo/WBPhenotype_0001368>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001368> (spermatheca absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0007816>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001373> (<http://purl.obolibrary.org/obo/WBPhenotype_0001373>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001373> (protein rna interaction abolished)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001373> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0022618>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001374> (<http://purl.obolibrary.org/obo/WBPhenotype_0001374>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001374> (pronuclear nuclear appearance variant emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001374> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001384> (<http://purl.obolibrary.org/obo/WBPhenotype_0001384>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001384> (fertility reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001384> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001385> (<http://purl.obolibrary.org/obo/WBPhenotype_0001385>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001385> (precocious oogenesis)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048477>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001387> (<http://purl.obolibrary.org/obo/WBPhenotype_0001387>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001387> (fertilization defect male)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001387> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009566>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001389> (<http://purl.obolibrary.org/obo/WBPhenotype_0001389>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001389> (cell gamma ray resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001389> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001390> (<http://purl.obolibrary.org/obo/WBPhenotype_0001390>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001390> (cell UV hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001390> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001392> (<http://purl.obolibrary.org/obo/WBPhenotype_0001392>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001392> (cell cycle arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001394> (<http://purl.obolibrary.org/obo/WBPhenotype_0001394>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001394> (cell acidification defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001394> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051452>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001397> (<http://purl.obolibrary.org/obo/WBPhenotype_0001397>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001397> (necrotic cell death increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001397> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0012501>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001402> (<http://purl.obolibrary.org/obo/WBPhenotype_0001402>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001402> (connected mitochondria)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001414> (<http://purl.obolibrary.org/obo/WBPhenotype_0001414>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001414> (male mating defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060179>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001419> (<http://purl.obolibrary.org/obo/WBPhenotype_0001419>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001419> (emetine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_4781>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001422> (<http://purl.obolibrary.org/obo/WBPhenotype_0001422>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001422> (endocytic transport defect)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006897>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001423> (<http://purl.obolibrary.org/obo/WBPhenotype_0001423>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001423> (coelomocyte physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005751>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001424> (<http://purl.obolibrary.org/obo/WBPhenotype_0001424>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001424> (oocyte physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001424> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006797>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001425> (<http://purl.obolibrary.org/obo/WBPhenotype_0001425>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001425> (receptor mediated endocytosis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006898>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001426> (<http://purl.obolibrary.org/obo/WBPhenotype_0001426>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001426> (coelomocyte uptake defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006897>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005751>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001432> (<http://purl.obolibrary.org/obo/WBPhenotype_0001432>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001432> (over retracted male tail)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001432> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001477> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001433> (<http://purl.obolibrary.org/obo/WBPhenotype_0001433>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001433> (precocious cell fusion)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001433> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000768>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001435> (<http://purl.obolibrary.org/obo/WBPhenotype_0001435>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001435> (ammonium chloride chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001435> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_31206>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001437> (<http://purl.obolibrary.org/obo/WBPhenotype_0001437>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001437> (octanol chemotaxis hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001437> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_37868>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001442> (<http://purl.obolibrary.org/obo/WBPhenotype_0001442>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001442> (sodium acetate chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_32954>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001486> (<http://purl.obolibrary.org/obo/WBPhenotype_0001486>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001486> (unfolded protein accumulation)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001486> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030968>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001493> (<http://purl.obolibrary.org/obo/WBPhenotype_0001493>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001493> (VPC cell division precocious)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007809>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001495> (<http://purl.obolibrary.org/obo/WBPhenotype_0001495>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001495> (cell division precocious)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001496> (<http://purl.obolibrary.org/obo/WBPhenotype_0001496>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001496> (metaphase to anaphase transition defect)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031577>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001497> (<http://purl.obolibrary.org/obo/WBPhenotype_0001497>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001497> (mitotic metaphase to anaphase transition defect)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007091>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/CL_0000586>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001498> (<http://purl.obolibrary.org/obo/WBPhenotype_0001498>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001498> (sperm pseudopod physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0031143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006798>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001502> (<http://purl.obolibrary.org/obo/WBPhenotype_0001502>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001502> (chemical resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0042221>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001509> (<http://purl.obolibrary.org/obo/WBPhenotype_0001509>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001509> (rays missing)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001515> (<http://purl.obolibrary.org/obo/WBPhenotype_0001515>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001515> (struts variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001515> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060109>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001516> (<http://purl.obolibrary.org/obo/WBPhenotype_0001516>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001516> (helical cuticle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001519> (<http://purl.obolibrary.org/obo/WBPhenotype_0001519>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001519> (posterior cell migration variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0016477>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001520> (<http://purl.obolibrary.org/obo/WBPhenotype_0001520>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001520> (posterior neuron migration variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001520> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0001764>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001523> (<http://purl.obolibrary.org/obo/WBPhenotype_0001523>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001523> (extracellular matrix variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031012>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001527> (<http://purl.obolibrary.org/obo/WBPhenotype_0001527>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001527> (amphid phasmid sensillum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001527> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005391>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001528> (<http://purl.obolibrary.org/obo/WBPhenotype_0001528>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001528> (sensillum accessory cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001528> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005762>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001529> (<http://purl.obolibrary.org/obo/WBPhenotype_0001529>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001529> (sensilium sheath cell variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001529> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000618>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001540> (<http://purl.obolibrary.org/obo/WBPhenotype_0001540>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001540> (dauer lifespan variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001540> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001545> (<http://purl.obolibrary.org/obo/WBPhenotype_0001545>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001545> (dauer body morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001545> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001550> (<http://purl.obolibrary.org/obo/WBPhenotype_0001550>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001550> (dauer buccal cavity morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001550> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005255>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001551> (<http://purl.obolibrary.org/obo/WBPhenotype_0001551>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001551> (dauer cuticle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001552> (<http://purl.obolibrary.org/obo/WBPhenotype_0001552>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001552> (dauer pharynx morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001553> (<http://purl.obolibrary.org/obo/WBPhenotype_0001553>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001553> (dauer excretory gland variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005776>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001556> (<http://purl.obolibrary.org/obo/WBPhenotype_0001556>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001556> (dauer sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001556> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001557> (<http://purl.obolibrary.org/obo/WBPhenotype_0001557>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001557> (dauer labial sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005107>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001558> (<http://purl.obolibrary.org/obo/WBPhenotype_0001558>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001558> (dauer amphid sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005391>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001559> (<http://purl.obolibrary.org/obo/WBPhenotype_0001559>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001559> (dauer deirid sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006926>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001561> (<http://purl.obolibrary.org/obo/WBPhenotype_0001561>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001561> (dauer inner labial sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001561> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005116>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001562> (<http://purl.obolibrary.org/obo/WBPhenotype_0001562>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001562> (dauer outer labial sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001562> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005501>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001563> (<http://purl.obolibrary.org/obo/WBPhenotype_0001563>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001563> (dauer cephalic sensillum variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001563> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006920>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001565> (<http://purl.obolibrary.org/obo/WBPhenotype_0001565>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001565> (lysine chemotaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001565> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_25094>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001567> (<http://purl.obolibrary.org/obo/WBPhenotype_0001567>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001567> (nuclei enlarged)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001574> (<http://purl.obolibrary.org/obo/WBPhenotype_0001574>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001574> (ATP levels variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15422>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001575> (<http://purl.obolibrary.org/obo/WBPhenotype_0001575>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001575> (ATP levels reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15422>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001576> (<http://purl.obolibrary.org/obo/WBPhenotype_0001576>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001576> (mitochondria spacing variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001577> (<http://purl.obolibrary.org/obo/WBPhenotype_0001577>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001577> (mitochondria alignment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001577> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001652> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001578> (<http://purl.obolibrary.org/obo/WBPhenotype_0001578>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001578> (cholinergic agonist resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001578> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38324>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001579> (<http://purl.obolibrary.org/obo/WBPhenotype_0001579>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001579> (cholinergic agonist hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001579> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38324>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001584> (<http://purl.obolibrary.org/obo/WBPhenotype_0001584>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001584> (chromosome alignment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001652> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005694>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001585> (<http://purl.obolibrary.org/obo/WBPhenotype_0001585>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001585> (asymmetric cell division variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001586> (<http://purl.obolibrary.org/obo/WBPhenotype_0001586>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001586> (multiple anchor cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004522>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001597> (<http://purl.obolibrary.org/obo/WBPhenotype_0001597>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001597> (muscle missing)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001599> (<http://purl.obolibrary.org/obo/WBPhenotype_0001599>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001599> (ouabain resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_472805>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001604> (<http://purl.obolibrary.org/obo/WBPhenotype_0001604>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001604> (mianserin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_51137>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001606> (<http://purl.obolibrary.org/obo/WBPhenotype_0001606>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001606> (ethanol hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_16236>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001608> (<http://purl.obolibrary.org/obo/WBPhenotype_0001608>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001608> (enflurane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_4792>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001609> (<http://purl.obolibrary.org/obo/WBPhenotype_0001609>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001609> (isoflurane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_6015>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001610> (<http://purl.obolibrary.org/obo/WBPhenotype_0001610>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001610> (diethyl ether hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_35702>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001611> (<http://purl.obolibrary.org/obo/WBPhenotype_0001611>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001611> (halothane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_5615>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001612> (<http://purl.obolibrary.org/obo/WBPhenotype_0001612>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001612> (ethanol resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_16236>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001615> (<http://purl.obolibrary.org/obo/WBPhenotype_0001615>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001615> (anticonvulsant resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001615> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_35623>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001618> (<http://purl.obolibrary.org/obo/WBPhenotype_0001618>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001618> (halothane resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001618> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_5615>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001619> (<http://purl.obolibrary.org/obo/WBPhenotype_0001619>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001619> (isoflurane resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001619> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_6015>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001622> (<http://purl.obolibrary.org/obo/WBPhenotype_0001622>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001622> (egg laying serotonin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001622> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001626> (<http://purl.obolibrary.org/obo/WBPhenotype_0001626>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001626> (locomotion rate serotonin variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007626>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001628> (<http://purl.obolibrary.org/obo/WBPhenotype_0001628>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001628> (locomotion rate serotonin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007626>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001629> (<http://purl.obolibrary.org/obo/WBPhenotype_0001629>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001629> (egg laying serotonin variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001629> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001630> (<http://purl.obolibrary.org/obo/WBPhenotype_0001630>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001630> (gut obstructed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001633> (<http://purl.obolibrary.org/obo/WBPhenotype_0001633>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001633> (lethal gamete)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000300>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001635> (<http://purl.obolibrary.org/obo/WBPhenotype_0001635>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001635> (excess pharyngeal cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002002> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005623>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001636> (<http://purl.obolibrary.org/obo/WBPhenotype_0001636>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001636> (excess intestinal cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001636> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005792>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001637> (<http://purl.obolibrary.org/obo/WBPhenotype_0001637>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001637> (no Intestine)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001637> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0005772>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001644> (<http://purl.obolibrary.org/obo/WBPhenotype_0001644>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001644> (protein metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0019538>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001645> (<http://purl.obolibrary.org/obo/WBPhenotype_0001645>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001645> (protein degradation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001645> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0030163>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001646> (<http://purl.obolibrary.org/obo/WBPhenotype_0001646>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001646> (no pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001649> (<http://purl.obolibrary.org/obo/WBPhenotype_0001649>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001649> (Fluorouracil resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_46345>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001653> (<http://purl.obolibrary.org/obo/WBPhenotype_0001653>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001653> (cadmium response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001653> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_22977>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001654> (<http://purl.obolibrary.org/obo/WBPhenotype_0001654>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001654> (cadmium resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001654> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_22977>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001655> (<http://purl.obolibrary.org/obo/WBPhenotype_0001655>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001655> (cadmium hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_22977>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001657> (<http://purl.obolibrary.org/obo/WBPhenotype_0001657>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001657> (cell junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0030054>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001658> (<http://purl.obolibrary.org/obo/WBPhenotype_0001658>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001658> (intercellular junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005911>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001667> (<http://purl.obolibrary.org/obo/WBPhenotype_0001667>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001667> (methyl methanesulfonate hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001667> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_25255>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001669> (<http://purl.obolibrary.org/obo/WBPhenotype_0001669>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001669> (presynaptic vesicle number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001669> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008021>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001671> (<http://purl.obolibrary.org/obo/WBPhenotype_0001671>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001671> (vesicle organization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016050>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001675> (<http://purl.obolibrary.org/obo/WBPhenotype_0001675>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001675> (male gonad development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001675> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0008584>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001681> (<http://purl.obolibrary.org/obo/WBPhenotype_0001681>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001681> (spindle orientation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001681> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001695> (<http://purl.obolibrary.org/obo/WBPhenotype_0001695>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001695> (glycosyltransferase activity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001695> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0016757>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001696> (<http://purl.obolibrary.org/obo/WBPhenotype_0001696>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001696> (biosynthesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001696> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0009058>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001705> (<http://purl.obolibrary.org/obo/WBPhenotype_0001705>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001705> (nucleocytoplasmic transport defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001705> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0006913>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001706> (<http://purl.obolibrary.org/obo/WBPhenotype_0001706>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001706> (nuclear export defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001706> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0051168>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001707> (<http://purl.obolibrary.org/obo/WBPhenotype_0001707>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001707> (nuclear import defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001707> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0051170>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001708> (<http://purl.obolibrary.org/obo/WBPhenotype_0001708>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001708> (protein export from nucleus defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001708> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0006611>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001711> (<http://purl.obolibrary.org/obo/WBPhenotype_0001711>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001711> (rhythmic behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001711> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0007622>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001712> (<http://purl.obolibrary.org/obo/WBPhenotype_0001712>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001712> (circadian rhythm behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001712> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0048512>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001719> (<http://purl.obolibrary.org/obo/WBPhenotype_0001719>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001719> (unfolded protein response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001719> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0030968>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001725> (<http://purl.obolibrary.org/obo/WBPhenotype_0001725>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001725> (osmotic stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001725> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0006970>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001739> (<http://purl.obolibrary.org/obo/WBPhenotype_0001739>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001739> (aging variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001739> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0007568>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001740> (<http://purl.obolibrary.org/obo/WBPhenotype_0001740>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001740> (organ senescence variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001740> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0010260>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001742> (<http://purl.obolibrary.org/obo/WBPhenotype_0001742>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001742> (lipid synthesis increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001742> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008610>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001743> (<http://purl.obolibrary.org/obo/WBPhenotype_0001743>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001743> (mitosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001743> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0000278>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001744> (<http://purl.obolibrary.org/obo/WBPhenotype_0001744>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001744> (cell adhesion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001744> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0007155>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001745> (<http://purl.obolibrary.org/obo/WBPhenotype_0001745>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001745> (adherens junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001745> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005912>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001746> (<http://purl.obolibrary.org/obo/WBPhenotype_0001746>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001746> (tight junction defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001746> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005923>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001747> (<http://purl.obolibrary.org/obo/WBPhenotype_0001747>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001747> (zinc response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001747> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_30185>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001749> (<http://purl.obolibrary.org/obo/WBPhenotype_0001749>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001749> (zinc toxicity hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001749> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_30185>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001750> (<http://purl.obolibrary.org/obo/WBPhenotype_0001750>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001750> (zinc toxicity resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_30185>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001752> (<http://purl.obolibrary.org/obo/WBPhenotype_0001752>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001752> (vesicle trafficking variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001752> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0016192>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001764> (<http://purl.obolibrary.org/obo/WBPhenotype_0001764>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001764> (carbon dioxide response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001764> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_16526>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001780> (<http://purl.obolibrary.org/obo/WBPhenotype_0001780>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001780> (associative learning variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008306>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001786> (<http://purl.obolibrary.org/obo/WBPhenotype_0001786>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001786> (neuronal ion channel clustering defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001786> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045161>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001787> (<http://purl.obolibrary.org/obo/WBPhenotype_0001787>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001787> (phototaxis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001787> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042331>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001788> (<http://purl.obolibrary.org/obo/WBPhenotype_0001788>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001788> (resistant to mutagens)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001788> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_25435>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001792> (<http://purl.obolibrary.org/obo/WBPhenotype_0001792>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001792> (nuclei small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_33252>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001794> (<http://purl.obolibrary.org/obo/WBPhenotype_0001794>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001794> (cytoplasmic processing body variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0000932>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001798> (<http://purl.obolibrary.org/obo/WBPhenotype_0001798>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001798> (inhibition of synaptogenesis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051964>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001799> (<http://purl.obolibrary.org/obo/WBPhenotype_0001799>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001799> (inhibition of synaptogenesis hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001799> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000760> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051964>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001806> (<http://purl.obolibrary.org/obo/WBPhenotype_0001806>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001806> (protein stabilization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001806> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050821>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001809> (<http://purl.obolibrary.org/obo/WBPhenotype_0001809>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001809> (organelle fusion defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001809> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048284>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001813> (<http://purl.obolibrary.org/obo/WBPhenotype_0001813>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001813> (synapsis defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001813> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007129>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001814> (<http://purl.obolibrary.org/obo/WBPhenotype_0001814>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001814> (crossover defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001814> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005712>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001826> (<http://purl.obolibrary.org/obo/WBPhenotype_0001826>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001826> (RNA degradation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006401>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001827> (<http://purl.obolibrary.org/obo/WBPhenotype_0001827>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001827> (RNA metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001827> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016070>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001828> (<http://purl.obolibrary.org/obo/WBPhenotype_0001828>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001828> (RNAi persistence variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001828> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000082> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001832> (<http://purl.obolibrary.org/obo/WBPhenotype_0001832>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001832> (nuclear pore variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001832> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005643>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001834> (<http://purl.obolibrary.org/obo/WBPhenotype_0001834>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001834> (mRNA splicing variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000374>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004013> (<http://purl.obolibrary.org/obo/WBPhenotype_0004013>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004013> (sperm release defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042713>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004017> (<http://purl.obolibrary.org/obo/WBPhenotype_0004017>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004017> (locomotor coordination variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000188> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004022> (<http://purl.obolibrary.org/obo/WBPhenotype_0004022>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004022> (amplitude of sinusoidal movement variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004022> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000080> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004024> (<http://purl.obolibrary.org/obo/WBPhenotype_0004024>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004024> (wavelength of movement variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004025> (<http://purl.obolibrary.org/obo/WBPhenotype_0004025>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004025> (velocity of movement variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 

--- a/src/ontology/wbphenotype-equivalent-axioms-subq.owl
+++ b/src/ontology/wbphenotype-equivalent-axioms-subq.owl
@@ -1502,10 +1502,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000043> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000049> (<http://purl.obolibrary.org/obo/WBPhenotype_0000049>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009791>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000050> (<http://purl.obolibrary.org/obo/WBPhenotype_0000050>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
@@ -1545,10 +1541,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000061> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000062> (<http://purl.obolibrary.org/obo/WBPhenotype_0000062>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000062> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000068> (<http://purl.obolibrary.org/obo/WBPhenotype_0000068>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000068> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006979>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000070> (<http://purl.obolibrary.org/obo/WBPhenotype_0000070>)
 
@@ -1598,37 +1590,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000090> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000091> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000093> (<http://purl.obolibrary.org/obo/WBPhenotype_0000093>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000093> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0000101>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000095> (<http://purl.obolibrary.org/obo/WBPhenotype_0000095>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000095> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004489>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000097> (<http://purl.obolibrary.org/obo/WBPhenotype_0000097>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000097> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004015>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000100> (<http://purl.obolibrary.org/obo/WBPhenotype_0000100>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000104> (<http://purl.obolibrary.org/obo/WBPhenotype_0000104>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000104> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007163>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000111> (<http://purl.obolibrary.org/obo/WBPhenotype_0000111>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000060> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000113> (<http://purl.obolibrary.org/obo/WBPhenotype_0000113>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006351>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000114> (<http://purl.obolibrary.org/obo/WBPhenotype_0000114>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000114> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009299>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000116> (<http://purl.obolibrary.org/obo/WBPhenotype_0000116>)
 
@@ -1654,10 +1618,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000125> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000126> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000127> (<http://purl.obolibrary.org/obo/WBPhenotype_0000127>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000127> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043054>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000134> (<http://purl.obolibrary.org/obo/WBPhenotype_0000134>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010467>))))
@@ -1678,10 +1638,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000137> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_35366>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000142> (<http://purl.obolibrary.org/obo/WBPhenotype_0000142>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033554>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000145> (<http://purl.obolibrary.org/obo/WBPhenotype_0000145>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000145> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -1689,10 +1645,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000145> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000155> (<http://purl.obolibrary.org/obo/WBPhenotype_0000155>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000155> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000625> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007163>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000159> (<http://purl.obolibrary.org/obo/WBPhenotype_0000159>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000159> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0022611>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000161> (<http://purl.obolibrary.org/obo/WBPhenotype_0000161>)
 
@@ -1713,10 +1665,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000164> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000165> (<http://purl.obolibrary.org/obo/WBPhenotype_0000165>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000768>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000168> (<http://purl.obolibrary.org/obo/WBPhenotype_0000168>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0046903>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000170> (<http://purl.obolibrary.org/obo/WBPhenotype_0000170>)
 
@@ -1778,14 +1726,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000190> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000197> (<http://purl.obolibrary.org/obo/WBPhenotype_0000197>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031129>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000202> (<http://purl.obolibrary.org/obo/WBPhenotype_0000202>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000202> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000214> (<http://purl.obolibrary.org/obo/WBPhenotype_0000214>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000214> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_37415>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
@@ -1834,10 +1774,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000237> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035177>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000239> (<http://purl.obolibrary.org/obo/WBPhenotype_0000239>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000239> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004432>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000244> (<http://purl.obolibrary.org/obo/WBPhenotype_0000244>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007140>))))
@@ -1882,10 +1818,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000274> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048511>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000278> (<http://purl.obolibrary.org/obo/WBPhenotype_0000278>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000278> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005738>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000279> (<http://purl.obolibrary.org/obo/WBPhenotype_0000279>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034609>))))
@@ -1913,14 +1845,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000290> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000291> (<http://purl.obolibrary.org/obo/WBPhenotype_0000291>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CL_0000023>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000292> (<http://purl.obolibrary.org/obo/WBPhenotype_0000292>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005746>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000293> (<http://purl.obolibrary.org/obo/WBPhenotype_0000293>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005748>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000294> (<http://purl.obolibrary.org/obo/WBPhenotype_0000294>)
 
@@ -1950,10 +1874,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000303> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15837>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000308> (<http://purl.obolibrary.org/obo/WBPhenotype_0000308>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000308> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040024>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000310> (<http://purl.obolibrary.org/obo/WBPhenotype_0000310>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006816>))))
@@ -1961,10 +1881,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000310> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000312> (<http://purl.obolibrary.org/obo/WBPhenotype_0000312>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042810>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000315> (<http://purl.obolibrary.org/obo/WBPhenotype_0000315>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000315> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001966>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000318> (<http://purl.obolibrary.org/obo/WBPhenotype_0000318>)
 
@@ -2001,10 +1917,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000341> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000344> (<http://purl.obolibrary.org/obo/WBPhenotype_0000344>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000344> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005774>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000345> (<http://purl.obolibrary.org/obo/WBPhenotype_0000345>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000345> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007809>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000350> (<http://purl.obolibrary.org/obo/WBPhenotype_0000350>)
 
@@ -2070,10 +1982,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000383> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000386> (<http://purl.obolibrary.org/obo/WBPhenotype_0000386>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000386> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008630>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000387> (<http://purl.obolibrary.org/obo/WBPhenotype_0000387>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000387> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>))))
@@ -2122,10 +2030,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000411> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_37868>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000416> (<http://purl.obolibrary.org/obo/WBPhenotype_0000416>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000416> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007296>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000417> (<http://purl.obolibrary.org/obo/WBPhenotype_0000417>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>))))
@@ -2166,18 +2070,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000441> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000445> (<http://purl.obolibrary.org/obo/WBPhenotype_0000445>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000445> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007296>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000447> (<http://purl.obolibrary.org/obo/WBPhenotype_0000447>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000447> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000448> (<http://purl.obolibrary.org/obo/WBPhenotype_0000448>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042335>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000451> (<http://purl.obolibrary.org/obo/WBPhenotype_0000451>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
@@ -2205,10 +2097,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000461> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000462> (<http://purl.obolibrary.org/obo/WBPhenotype_0000462>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_34905>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000463> (<http://purl.obolibrary.org/obo/WBPhenotype_0000463>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0044237>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000464> (<http://purl.obolibrary.org/obo/WBPhenotype_0000464>)
 
@@ -2278,10 +2166,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000499> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000503> (<http://purl.obolibrary.org/obo/WBPhenotype_0000503>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000503> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042023>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000507> (<http://purl.obolibrary.org/obo/WBPhenotype_0000507>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15355>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -2290,33 +2174,13 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000507> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000508> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000184>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000509> (<http://purl.obolibrary.org/obo/WBPhenotype_0000509>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0031143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006798>))))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000511> (<http://purl.obolibrary.org/obo/WBPhenotype_0000511>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051647>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000516> (<http://purl.obolibrary.org/obo/WBPhenotype_0000516>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005829>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000518> (<http://purl.obolibrary.org/obo/WBPhenotype_0000518>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000518> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (<http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000523> (<http://purl.obolibrary.org/obo/WBPhenotype_0000523>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042221>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000526> (<http://purl.obolibrary.org/obo/WBPhenotype_0000526>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000526> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033059>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (<http://purl.obolibrary.org/obo/WBPhenotype_0000536>)
 
@@ -2341,10 +2205,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000552> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000553> (<http://purl.obolibrary.org/obo/WBPhenotype_0000553>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032982>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000558> (<http://purl.obolibrary.org/obo/WBPhenotype_0000558>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_38808>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000559> (<http://purl.obolibrary.org/obo/WBPhenotype_0000559>)
 
@@ -2410,25 +2270,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000612> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000613> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005747>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000627> (<http://purl.obolibrary.org/obo/WBPhenotype_0000627>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000627> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_38867>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000628> (<http://purl.obolibrary.org/obo/WBPhenotype_0000628>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051225>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000630> (<http://purl.obolibrary.org/obo/WBPhenotype_0000630>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15854>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000632> (<http://purl.obolibrary.org/obo/WBPhenotype_0000632>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007413>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000636> (<http://purl.obolibrary.org/obo/WBPhenotype_0000636>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000636> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051402>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000642> (<http://purl.obolibrary.org/obo/WBPhenotype_0000642>)
 
@@ -2446,10 +2290,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000644> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000648> (<http://purl.obolibrary.org/obo/WBPhenotype_0000648>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060179>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000649> (<http://purl.obolibrary.org/obo/WBPhenotype_0000649>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -2457,14 +2297,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000649> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000651> (<http://purl.obolibrary.org/obo/WBPhenotype_0000651>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030421>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000655> (<http://purl.obolibrary.org/obo/WBPhenotype_0000655>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051932>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000656> (<http://purl.obolibrary.org/obo/WBPhenotype_0000656>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007271>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000660> (<http://purl.obolibrary.org/obo/WBPhenotype_0000660>)
 
@@ -2502,10 +2334,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000676> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000680> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000681> (<http://purl.obolibrary.org/obo/WBPhenotype_0000681>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000681> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_4290>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000682> (<http://purl.obolibrary.org/obo/WBPhenotype_0000682>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000682> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000467> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040022>))))
@@ -2517,10 +2345,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000684> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000688> (<http://purl.obolibrary.org/obo/WBPhenotype_0000688>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000688> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000956> <http://purl.obolibrary.org/obo/PATO_0001767> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000690> (<http://purl.obolibrary.org/obo/WBPhenotype_0000690>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0008354>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000692> (<http://purl.obolibrary.org/obo/WBPhenotype_0000692>)
 
@@ -2562,85 +2386,21 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000707> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000715> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000716> (<http://purl.obolibrary.org/obo/WBPhenotype_0000716>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000716> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0098609>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000717> (<http://purl.obolibrary.org/obo/WBPhenotype_0000717>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000717> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010467>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000726> (<http://purl.obolibrary.org/obo/WBPhenotype_0000726>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000726> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005102>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000727> (<http://purl.obolibrary.org/obo/WBPhenotype_0000727>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000727> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000731> (<http://purl.obolibrary.org/obo/WBPhenotype_0000731>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000731> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0006796>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000733> (<http://purl.obolibrary.org/obo/WBPhenotype_0000733>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000733> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000734> (<http://purl.obolibrary.org/obo/WBPhenotype_0000734>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000734> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000735> (<http://purl.obolibrary.org/obo/WBPhenotype_0000735>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000735> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042023>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000737> (<http://purl.obolibrary.org/obo/WBPhenotype_0000737>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000737> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0006796>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000738> (<http://purl.obolibrary.org/obo/WBPhenotype_0000738>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000738> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050896>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000743> (<http://purl.obolibrary.org/obo/WBPhenotype_0000743>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000743> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0016246>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000748> (<http://purl.obolibrary.org/obo/WBPhenotype_0000748>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000748> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008356>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000751> (<http://purl.obolibrary.org/obo/WBPhenotype_0000751>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000751> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000027>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000752> (<http://purl.obolibrary.org/obo/WBPhenotype_0000752>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000752> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000027>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000753> (<http://purl.obolibrary.org/obo/WBPhenotype_0000753>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000753> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000027>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000754> (<http://purl.obolibrary.org/obo/WBPhenotype_0000754>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000754> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000038>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000756> (<http://purl.obolibrary.org/obo/WBPhenotype_0000756>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000756> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBls_0000029>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000757> (<http://purl.obolibrary.org/obo/WBPhenotype_0000757>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000757> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBls_0000037>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000758> (<http://purl.obolibrary.org/obo/WBPhenotype_0000758>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000758> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBls_0000040>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000759> (<http://purl.obolibrary.org/obo/WBPhenotype_0000759>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000759> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000760> (<http://purl.obolibrary.org/obo/WBPhenotype_0000760>)
 
@@ -2654,22 +2414,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000762> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007028>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000764> (<http://purl.obolibrary.org/obo/WBPhenotype_0000764>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000764> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016043>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007028>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000765> (<http://purl.obolibrary.org/obo/WBPhenotype_0000765>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000765> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051231>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000766> (<http://purl.obolibrary.org/obo/WBPhenotype_0000766>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000766> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035047>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000767> (<http://purl.obolibrary.org/obo/WBPhenotype_0000767>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000767> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043227>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000768> (<http://purl.obolibrary.org/obo/WBPhenotype_0000768>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000768> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000141> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -2678,21 +2422,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000768> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000769> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000772> (<http://purl.obolibrary.org/obo/WBPhenotype_0000772>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000772> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000775> (<http://purl.obolibrary.org/obo/WBPhenotype_0000775>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000775> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000776> (<http://purl.obolibrary.org/obo/WBPhenotype_0000776>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000776> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033313>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000777> (<http://purl.obolibrary.org/obo/WBPhenotype_0000777>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000777> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040038>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000778> (<http://purl.obolibrary.org/obo/WBPhenotype_0000778>)
 
@@ -2705,14 +2437,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000783> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000784> (<http://purl.obolibrary.org/obo/WBPhenotype_0000784>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000784> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000785> (<http://purl.obolibrary.org/obo/WBPhenotype_0000785>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000785> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0003760>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000786> (<http://purl.obolibrary.org/obo/WBPhenotype_0000786>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000786> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005768>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000789> (<http://purl.obolibrary.org/obo/WBPhenotype_0000789>)
 
@@ -2729,70 +2453,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000803> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000806> (<http://purl.obolibrary.org/obo/WBPhenotype_0000806>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000806> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007849>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000807> (<http://purl.obolibrary.org/obo/WBPhenotype_0000807>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000807> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004780>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000808> (<http://purl.obolibrary.org/obo/WBPhenotype_0000808>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000808> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004499>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000825> (<http://purl.obolibrary.org/obo/WBPhenotype_0000825>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000825> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0000101>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000022>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000826> (<http://purl.obolibrary.org/obo/WBPhenotype_0000826>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004778>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000828> (<http://purl.obolibrary.org/obo/WBPhenotype_0000828>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000828> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004946>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000829> (<http://purl.obolibrary.org/obo/WBPhenotype_0000829>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000829> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008593>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000830> (<http://purl.obolibrary.org/obo/WBPhenotype_0000830>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000830> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003825>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000831> (<http://purl.obolibrary.org/obo/WBPhenotype_0000831>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000831> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004578>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000832> (<http://purl.obolibrary.org/obo/WBPhenotype_0000832>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000832> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003810>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000833> (<http://purl.obolibrary.org/obo/WBPhenotype_0000833>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000833> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004942>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000834> (<http://purl.obolibrary.org/obo/WBPhenotype_0000834>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004804>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000835> (<http://purl.obolibrary.org/obo/WBPhenotype_0000835>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000835> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004799>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000839> (<http://purl.obolibrary.org/obo/WBPhenotype_0000839>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004216>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000840> (<http://purl.obolibrary.org/obo/WBPhenotype_0000840>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000840> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0000101>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000841> (<http://purl.obolibrary.org/obo/WBPhenotype_0000841>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000841> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005022>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000842> (<http://purl.obolibrary.org/obo/WBPhenotype_0000842>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000842> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005024>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000846> (<http://purl.obolibrary.org/obo/WBPhenotype_0000846>)
 
@@ -2830,10 +2490,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000867> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000868> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005738>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000879> (<http://purl.obolibrary.org/obo/WBPhenotype_0000879>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000879> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000723>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000881> (<http://purl.obolibrary.org/obo/WBPhenotype_0000881>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000881> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006816>))))
@@ -2862,33 +2518,13 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000931> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000932> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_33216>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042221>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000933> (<http://purl.obolibrary.org/obo/WBPhenotype_0000933>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000933> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004458>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000934> (<http://purl.obolibrary.org/obo/WBPhenotype_0000934>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000934> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000935> (<http://purl.obolibrary.org/obo/WBPhenotype_0000935>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000935> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004873>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000936> (<http://purl.obolibrary.org/obo/WBPhenotype_0000936>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000936> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004421>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000937> (<http://purl.obolibrary.org/obo/WBPhenotype_0000937>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000937> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004583>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000964> (<http://purl.obolibrary.org/obo/WBPhenotype_0000964>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000964> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_4290>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000965> (<http://purl.obolibrary.org/obo/WBPhenotype_0000965>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000965> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008219>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/CL_0002371>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000966> (<http://purl.obolibrary.org/obo/WBPhenotype_0000966>)
 
@@ -2913,10 +2549,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000976> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000978> (<http://purl.obolibrary.org/obo/WBPhenotype_0000978>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005319>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000981> (<http://purl.obolibrary.org/obo/WBPhenotype_0000981>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000981> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007285>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000983> (<http://purl.obolibrary.org/obo/WBPhenotype_0000983>)
 
@@ -2958,10 +2590,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001006> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000041>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001018> (<http://purl.obolibrary.org/obo/WBPhenotype_0001018>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000910>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000003>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001019> (<http://purl.obolibrary.org/obo/WBPhenotype_0001019>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#ends_during_or_before> <http://purl.obolibrary.org/obo/WBls_0000027>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#starts_during_or_after> <http://purl.obolibrary.org/obo/WBls_0000027>))))
@@ -2974,10 +2602,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001020> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001026> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001027> (<http://purl.obolibrary.org/obo/WBPhenotype_0001027>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001027> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051647>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001031> (<http://purl.obolibrary.org/obo/WBPhenotype_0001031>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
@@ -2985,10 +2609,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001031> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001034> (<http://purl.obolibrary.org/obo/WBPhenotype_0001034>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001040> (<http://purl.obolibrary.org/obo/WBPhenotype_0001040>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007635>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001041> (<http://purl.obolibrary.org/obo/WBPhenotype_0001041>)
 
@@ -2998,17 +2618,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001041> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001043> (<http://purl.obolibrary.org/obo/WBPhenotype_0001043>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051318>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001046> (<http://purl.obolibrary.org/obo/WBPhenotype_0001046>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005451>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001053> (<http://purl.obolibrary.org/obo/WBPhenotype_0001053>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_23447>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001054> (<http://purl.obolibrary.org/obo/WBPhenotype_0001054>)
 
@@ -3050,14 +2662,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001074> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001075> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001077> (<http://purl.obolibrary.org/obo/WBPhenotype_0001077>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001078> (<http://purl.obolibrary.org/obo/WBPhenotype_0001078>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001078> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000910>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001081> (<http://purl.obolibrary.org/obo/WBPhenotype_0001081>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001081> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/CL_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -3094,14 +2698,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001098> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001101> (<http://purl.obolibrary.org/obo/WBPhenotype_0001101>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001101> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_23888>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001102> (<http://purl.obolibrary.org/obo/WBPhenotype_0001102>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001102> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/GO_0000278>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001103> (<http://purl.obolibrary.org/obo/WBPhenotype_0001103>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
@@ -3121,30 +2717,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001106> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001107> (<http://purl.obolibrary.org/obo/WBPhenotype_0001107>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001107> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001110> (<http://purl.obolibrary.org/obo/WBPhenotype_0001110>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001110> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005818>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001111> (<http://purl.obolibrary.org/obo/WBPhenotype_0001111>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0004015>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005818>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001113> (<http://purl.obolibrary.org/obo/WBPhenotype_0001113>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006770>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005818>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001114> (<http://purl.obolibrary.org/obo/WBPhenotype_0001114>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001114> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001115> (<http://purl.obolibrary.org/obo/WBPhenotype_0001115>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001115> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051726>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001117> (<http://purl.obolibrary.org/obo/WBPhenotype_0001117>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007267>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001118> (<http://purl.obolibrary.org/obo/WBPhenotype_0001118>)
 
@@ -3174,14 +2746,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001136> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001138> (<http://purl.obolibrary.org/obo/WBPhenotype_0001138>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001139> (<http://purl.obolibrary.org/obo/WBPhenotype_0001139>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001139> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031468>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001142> (<http://purl.obolibrary.org/obo/WBPhenotype_0001142>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
@@ -3190,21 +2754,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001142> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001151> (<http://purl.obolibrary.org/obo/WBPhenotype_0001151>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001151> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001152> (<http://purl.obolibrary.org/obo/WBPhenotype_0001152>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001152> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001153> (<http://purl.obolibrary.org/obo/WBPhenotype_0001153>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001153> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001154> (<http://purl.obolibrary.org/obo/WBPhenotype_0001154>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001154> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018985>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0001940>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001156> (<http://purl.obolibrary.org/obo/WBPhenotype_0001156>)
 
@@ -3230,10 +2782,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001165> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001940>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001167> (<http://purl.obolibrary.org/obo/WBPhenotype_0001167>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030588>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001168> (<http://purl.obolibrary.org/obo/WBPhenotype_0001168>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0030588>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
@@ -3250,17 +2798,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001170> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001173> (<http://purl.obolibrary.org/obo/WBPhenotype_0001173>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001173> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0012501>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001176> (<http://purl.obolibrary.org/obo/WBPhenotype_0001176>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000006>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001178> (<http://purl.obolibrary.org/obo/WBPhenotype_0001178>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000025>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001182> (<http://purl.obolibrary.org/obo/WBPhenotype_0001182>)
 
@@ -3281,10 +2821,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001190> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001191> (<http://purl.obolibrary.org/obo/WBPhenotype_0001191>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005451>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001192> (<http://purl.obolibrary.org/obo/WBPhenotype_0001192>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0019722>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001194> (<http://purl.obolibrary.org/obo/WBPhenotype_0001194>)
 
@@ -3314,14 +2850,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001202> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001203> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_17688>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001206> (<http://purl.obolibrary.org/obo/WBPhenotype_0001206>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001206> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007626>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001207> (<http://purl.obolibrary.org/obo/WBPhenotype_0001207>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007165>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001208> (<http://purl.obolibrary.org/obo/WBPhenotype_0001208>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>))))
@@ -3329,10 +2857,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001208> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (<http://purl.obolibrary.org/obo/WBPhenotype_0001210>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001211> (<http://purl.obolibrary.org/obo/WBPhenotype_0001211>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001211> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001212> (<http://purl.obolibrary.org/obo/WBPhenotype_0001212>)
 
@@ -3345,10 +2869,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001213> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001216> (<http://purl.obolibrary.org/obo/WBPhenotype_0001216>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001216> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033316>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001224> (<http://purl.obolibrary.org/obo/WBPhenotype_0001224>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001224> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048846>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001225> (<http://purl.obolibrary.org/obo/WBPhenotype_0001225>)
 
@@ -3418,17 +2938,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001262> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005777>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001268> (<http://purl.obolibrary.org/obo/WBPhenotype_0001268>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001268> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001281> (<http://purl.obolibrary.org/obo/WBPhenotype_0001281>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001836> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001283> (<http://purl.obolibrary.org/obo/WBPhenotype_0001283>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001283> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008152>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/GO_0043226>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001289> (<http://purl.obolibrary.org/obo/WBPhenotype_0001289>)
 
@@ -3453,10 +2965,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001294> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001296> (<http://purl.obolibrary.org/obo/WBPhenotype_0001296>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_6835>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001299> (<http://purl.obolibrary.org/obo/WBPhenotype_0001299>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001299> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001300> (<http://purl.obolibrary.org/obo/WBPhenotype_0001300>)
 
@@ -3490,17 +2998,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001314> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001322> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031982>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001324> (<http://purl.obolibrary.org/obo/WBPhenotype_0001324>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010212>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001325> (<http://purl.obolibrary.org/obo/WBPhenotype_0001325>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001570> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0043057>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001326> (<http://purl.obolibrary.org/obo/WBPhenotype_0001326>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005623>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001327> (<http://purl.obolibrary.org/obo/WBPhenotype_0001327>)
 
@@ -3530,22 +3030,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001340> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001343> (<http://purl.obolibrary.org/obo/WBPhenotype_0001343>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001343> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001344> (<http://purl.obolibrary.org/obo/WBPhenotype_0001344>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001344> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006996>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001345> (<http://purl.obolibrary.org/obo/WBPhenotype_0001345>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001345> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007010>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001346> (<http://purl.obolibrary.org/obo/WBPhenotype_0001346>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001346> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032956>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001350> (<http://purl.obolibrary.org/obo/WBPhenotype_0001350>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006468>))))
@@ -3553,10 +3037,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001350> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001351> (<http://purl.obolibrary.org/obo/WBPhenotype_0001351>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006468>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001352> (<http://purl.obolibrary.org/obo/WBPhenotype_0001352>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008152>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/GO_0005783>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001358> (<http://purl.obolibrary.org/obo/WBPhenotype_0001358>)
 
@@ -3570,25 +3050,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001362> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002112> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001365> (<http://purl.obolibrary.org/obo/WBPhenotype_0001365>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001365> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048540>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001368> (<http://purl.obolibrary.org/obo/WBPhenotype_0001368>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0007816>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001369> (<http://purl.obolibrary.org/obo/WBPhenotype_0001369>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001369> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0065003>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001370> (<http://purl.obolibrary.org/obo/WBPhenotype_0001370>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001370> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0065003>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001372> (<http://purl.obolibrary.org/obo/WBPhenotype_0001372>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001372> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0065004>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001373> (<http://purl.obolibrary.org/obo/WBPhenotype_0001373>)
 
@@ -3622,10 +3086,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001390> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001393> (<http://purl.obolibrary.org/obo/WBPhenotype_0001393>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051452>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001394> (<http://purl.obolibrary.org/obo/WBPhenotype_0001394>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001394> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051452>))))
@@ -3638,10 +3098,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001397> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005739>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001405> (<http://purl.obolibrary.org/obo/WBPhenotype_0001405>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051259>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001414> (<http://purl.obolibrary.org/obo/WBPhenotype_0001414>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060179>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000056>))))
@@ -3649,10 +3105,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001414> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001419> (<http://purl.obolibrary.org/obo/WBPhenotype_0001419>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_4781>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001421> (<http://purl.obolibrary.org/obo/WBPhenotype_0001421>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006897>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001422> (<http://purl.obolibrary.org/obo/WBPhenotype_0001422>)
 
@@ -3674,10 +3126,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001425> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006897>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBbt_0005751>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001430> (<http://purl.obolibrary.org/obo/WBPhenotype_0001430>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007040>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001432> (<http://purl.obolibrary.org/obo/WBPhenotype_0001432>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001432> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001477> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>))))
@@ -3697,82 +3145,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001437> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001442> (<http://purl.obolibrary.org/obo/WBPhenotype_0001442>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_32954>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001452> (<http://purl.obolibrary.org/obo/WBPhenotype_0001452>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_37868>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001454> (<http://purl.obolibrary.org/obo/WBPhenotype_0001454>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001454> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15854>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001456> (<http://purl.obolibrary.org/obo/WBPhenotype_0001456>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_25579>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001457> (<http://purl.obolibrary.org/obo/WBPhenotype_0001457>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15858>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001458> (<http://purl.obolibrary.org/obo/WBPhenotype_0001458>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001458> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_17996>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001459> (<http://purl.obolibrary.org/obo/WBPhenotype_0001459>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_16382>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001460> (<http://purl.obolibrary.org/obo/WBPhenotype_0001460>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_31206>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001461> (<http://purl.obolibrary.org/obo/WBPhenotype_0001461>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001461> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_32954>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001462> (<http://purl.obolibrary.org/obo/WBPhenotype_0001462>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_26710>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001463> (<http://purl.obolibrary.org/obo/WBPhenotype_0001463>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_17489>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001464> (<http://purl.obolibrary.org/obo/WBPhenotype_0001464>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001464> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_27682>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001465> (<http://purl.obolibrary.org/obo/WBPhenotype_0001465>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001465> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15347>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001468> (<http://purl.obolibrary.org/obo/WBPhenotype_0001468>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001468> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_22698>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001469> (<http://purl.obolibrary.org/obo/WBPhenotype_0001469>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001469> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_22951>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001470> (<http://purl.obolibrary.org/obo/WBPhenotype_0001470>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_16583>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001471> (<http://purl.obolibrary.org/obo/WBPhenotype_0001471>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001471> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_18099>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001472> (<http://purl.obolibrary.org/obo/WBPhenotype_0001472>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001472> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_15837>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001474> (<http://purl.obolibrary.org/obo/WBPhenotype_0001474>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001474> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_30953>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001485> (<http://purl.obolibrary.org/obo/WBPhenotype_0001485>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001485> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006983>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001486> (<http://purl.obolibrary.org/obo/WBPhenotype_0001486>)
 
@@ -3798,10 +3170,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001497> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0031143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBbt_0006798>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001500> (<http://purl.obolibrary.org/obo/WBPhenotype_0001500>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_38366>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001502> (<http://purl.obolibrary.org/obo/WBPhenotype_0001502>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/GO_0042221>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>))))
@@ -3809,10 +3177,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001502> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001509> (<http://purl.obolibrary.org/obo/WBPhenotype_0001509>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0006941>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001514> (<http://purl.obolibrary.org/obo/WBPhenotype_0001514>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001514> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048488>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001515> (<http://purl.obolibrary.org/obo/WBPhenotype_0001515>)
 
@@ -3850,17 +3214,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001529> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001540> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001541> (<http://purl.obolibrary.org/obo/WBPhenotype_0001541>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001541> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008406>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001545> (<http://purl.obolibrary.org/obo/WBPhenotype_0001545>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001545> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001547> (<http://purl.obolibrary.org/obo/WBPhenotype_0001547>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001547> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008152>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001550> (<http://purl.obolibrary.org/obo/WBPhenotype_0001550>)
 
@@ -3877,10 +3233,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001552> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001553> (<http://purl.obolibrary.org/obo/WBPhenotype_0001553>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005776>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000032>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001555> (<http://purl.obolibrary.org/obo/WBPhenotype_0001555>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048880>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001556> (<http://purl.obolibrary.org/obo/WBPhenotype_0001556>)
 
@@ -3918,10 +3270,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001565> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001573> (<http://purl.obolibrary.org/obo/WBPhenotype_0001573>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_18723>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001574> (<http://purl.obolibrary.org/obo/WBPhenotype_0001574>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15422>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -3946,10 +3294,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001578> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001579> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_38324>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001580> (<http://purl.obolibrary.org/obo/WBPhenotype_0001580>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001580> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051081>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000004>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001584> (<http://purl.obolibrary.org/obo/WBPhenotype_0001584>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001652> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005694>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
@@ -3962,41 +3306,9 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001585> ObjectSom
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004522>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001587> (<http://purl.obolibrary.org/obo/WBPhenotype_0001587>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030036>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001588> (<http://purl.obolibrary.org/obo/WBPhenotype_0001588>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001588> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000226>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001589> (<http://purl.obolibrary.org/obo/WBPhenotype_0001589>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007020>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001590> (<http://purl.obolibrary.org/obo/WBPhenotype_0001590>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001590> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007019>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001591> (<http://purl.obolibrary.org/obo/WBPhenotype_0001591>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001591> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007019>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001593> (<http://purl.obolibrary.org/obo/WBPhenotype_0001593>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001593> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001594> (<http://purl.obolibrary.org/obo/WBPhenotype_0001594>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016246>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/CL_0000586>))))
-
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001597> (<http://purl.obolibrary.org/obo/WBPhenotype_0001597>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/WBbt_0003675>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001598> (<http://purl.obolibrary.org/obo/WBPhenotype_0001598>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0014076>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001599> (<http://purl.obolibrary.org/obo/WBPhenotype_0001599>)
 
@@ -4029,10 +3341,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001611> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001612> (<http://purl.obolibrary.org/obo/WBPhenotype_0001612>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000070> <http://purl.obolibrary.org/obo/CHEBI_16236>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001614> (<http://purl.obolibrary.org/obo/WBPhenotype_0001614>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001614> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#in_response_to> <http://purl.obolibrary.org/obo/CHEBI_35623>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001615> (<http://purl.obolibrary.org/obo/WBPhenotype_0001615>)
 
@@ -4293,10 +3601,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001832> ObjectSom
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001834> (<http://purl.obolibrary.org/obo/WBPhenotype_0001834>)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000374>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004001> (<http://purl.obolibrary.org/obo/WBPhenotype_0004001>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007617>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/wbphenotype/wbphenotype-equivalent-axioms-subq#during> <http://purl.obolibrary.org/obo/WBls_0000057>))))
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004013> (<http://purl.obolibrary.org/obo/WBPhenotype_0004013>)
 


### PR DESCRIPTION
I made note of the original (Mungall) EQ definitions for each term:

https://docs.google.com/spreadsheets/d/1s0PYehFsnTp7yimA3Kxwvv3GRwAxz8ZTS1TFIhMs0k0/edit?usp=sharing

and removed all relevant EQ defs from the axioms file:

~/src/ontology/wbphenotype-equivalent-axioms-subq.owl