### PR TITLE
Label changes and obsoletion of 'organismal phenotype'

### DIFF
--- a/src/ontology/wbphenotype-edit.owl
+++ b/src/ontology/wbphenotype-edit.owl
@@ -3068,16 +3068,17 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000038> "exploded through vulva"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000038> <http://purl.obolibrary.org/obo/WBPhenotype_0000619>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000039> (life span variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000039> (life span phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0008340"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00005863"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00026717"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:cab"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "Adult life span is either longer or shorter than typical of control animals."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "Age"^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "life span abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "life span abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "life span variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "longevity abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "WBPhenotype:0000039"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000039> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "life span variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000039> "life span phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000039> <http://purl.obolibrary.org/obo/WBPhenotype_0000576>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000040> (one cell arrest early emb)
@@ -4067,14 +4068,15 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_00001
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000144> <http://purl.obolibrary.org/obo/WBPhenotype_0000142>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000144> <http://purl.obolibrary.org/obo/WBPhenotype_0001269>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000145> (fertility variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000145> (fertility phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0000003"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "Animals exhibit variations in the time of onset or duration of the fertile period, or production of new individuals that contain some portion of their genetic material inherited from that organism compared to control."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "fertility variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "fertility abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "WBPhenotype:0000145"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000145> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "fertility variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000145> "fertility phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000145> <http://purl.obolibrary.org/obo/WBPhenotype_0000613>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000146> (organism temperature response variant)
@@ -5267,13 +5269,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <htt
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000277> "rhythm slow"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000277> <http://purl.obolibrary.org/obo/WBPhenotype_0000525>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000278> (body region pigmentation variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000278> (body region pigmentation phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "Animals exhibit variations in the accumulation or expression of biochromes or any other substances that alter transparency or translucency of a particular body region."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "body region pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "body region pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "body region pigmentation variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "WBPhenotype:0000278"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "body region pigmentation variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000278> "body region pigmentation phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000278> <http://purl.obolibrary.org/obo/WBPhenotype_0000521>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000279> (spicule insertion defective)
@@ -5392,13 +5395,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000291> "no oocytes"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000291> <http://purl.obolibrary.org/obo/WBPhenotype_0000395>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000292> (organ system pigmentation variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000292> (organ system pigmentation phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "Animals exhibit variations in the accumulation or expression of biochromes or any other substances that alter transparency/translucency of a organ system."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "organ system pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "organ system pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "organ system pigmentation variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "WBPhenotype:0000292"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "organ system pigmentation variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000292> "organ system pigmentation phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000292> <http://purl.obolibrary.org/obo/WBPhenotype_0000521>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000293> (alimentary system pigmentation variant)
@@ -5537,17 +5541,18 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000307> "dauer pheromone sensation defective"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000307> <http://purl.obolibrary.org/obo/WBPhenotype_0001479>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000308> (dauer development variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000308> (dauer development phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:kmva"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "Any variation in the processes that govern development of the dauer larva, a developmentally arrested, larval stage that is specialized for survival under harsh, or otherwise unfavorable, environmental conditions. In C. elegans this is an alternative third larval stage."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "WBPhenotype:0000159"^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer development variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer arrest abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer arrest variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "diapause variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "WBPhenotype:0000308"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer development variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000308> "dauer development phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000308> <http://purl.obolibrary.org/obo/WBPhenotype_0000750>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000308> <http://purl.obolibrary.org/obo/WBPhenotype_0002527>)
 
@@ -7386,50 +7391,55 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000516> "ventral cord disorganized"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000516> <http://purl.obolibrary.org/obo/WBPhenotype_0000976>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000517> (behavior variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000517> (behavior phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0007610"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "Variations in the specific actions or reactions in response to external or internal stimuli compared to that observed in control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "behavior abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "behavior abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "behavior variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "WBPhenotype:0000517"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "behavior variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000517> "behavior phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000517> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000518> (development variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000518> (development phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0032502"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "Variations in the progression of an integrated living unit (a cell, tissue, organ or organism) over time from an initial condition to a later condition compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "development abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "development variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "WBPhenotype:0000518"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "development variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000518> "development phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000518> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "Animals exhibit variations in any physical or chemical process required for the cell, tissue, organ system or organism to carry out its normal functions and activities or be able to perceive and respond to stimuli compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "WBPhenotype:0000519"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000519> "physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000519> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000520> (morphology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000520> (morphology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "Animals exhibit variations in the form, structure or composition of any of its parts compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "morphology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "WBPhenotype:0000520"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "morphology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000520> "morphology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000520> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000521> (pigmentation variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000521> (pigmentation phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "Animals exhibit variations in the accumulation or expression of biochromes or any other substances that alter transparency/translucency."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "pigmentation variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "WBPhenotype:0000521"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000521> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "pigmentation variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000521> "pigmentation phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000521> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000522> (organism region behavior variant)
@@ -7469,25 +7479,27 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <htt
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000525> "organism behavior variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000525> <http://purl.obolibrary.org/obo/WBPhenotype_0000517>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000526> (cell pigmentation variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000526> (cell pigmentation phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "Animals exhibit variations in the accumulation or expression of biochromes or any other substances that alter transparency/translucency of a cell."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "cell pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "cell pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "cell pigmentation variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "WBPhenotype:0000526"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000526> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "cell pigmentation variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000526> "cell pigmentation phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000526> <http://purl.obolibrary.org/obo/WBPhenotype_0000521>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000527> (organism pigmentation variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000527> (organism pigmentation phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "Animals exhibit variations in the accumulation or expression of biochromes or any other substances that alter transparency/translucency of the organism."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "organism pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "organism pigmentation abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "organism pigmentation variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "Abnormal Coloration"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "WBPhenotype:0000527"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000527> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "organism pigmentation variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000527> "organism pigmentation phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000527> <http://purl.obolibrary.org/obo/WBPhenotype_0000521>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000528> (body region development variant)
@@ -7570,14 +7582,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <htt
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000535> "organism morphology variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000535> <http://purl.obolibrary.org/obo/WBPhenotype_0000520>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (cell physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (cell physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0009987"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "Animals exhibit variations at the cellular level, but not necessarily restricted to a single cell, in any physical or chemical process required for the cell to carry out its normal functions or be able to perceive and respond to stimuli, compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "cell physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "cell physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "cell physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "WBPhenotype:0000536"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000536> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "cell physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000536> "cell physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000536> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000537> (obsolete synaptic input abnormal)
@@ -7924,24 +7937,26 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000574> "excretory canal short"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000574> <http://purl.obolibrary.org/obo/WBPhenotype_0000704>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (organ system physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (organ system physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0003008"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "Animals exhibit variations in a physical or chemical process required for organs or tissues to carry out their normal functions or for their ability to perceive and respond to stimuli compared to control."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "organ system physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "organ system physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "organ system physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "WBPhenotype:0000575"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000575> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "organ system physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000575> "organ system physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000575> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (organism physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (organism physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "Animals exhibit variations in any physical or chemical process required for the organism to carry out its normal function or be able to perceive and respond to stimuli."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "organism physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "organism physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "organism physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "WBPhenotype:0000576"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000576> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "organism physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000576> "organism physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000576> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000577> (organism homeostasis metabolism variant)
@@ -10917,16 +10932,17 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000885> "engulfment variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000885> <http://purl.obolibrary.org/obo/WBPhenotype_0000730>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000886> (Variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000886> (nematode phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "Animals exhibit variations compared to a given control."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "Abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "Abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "not WT"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "not wildtype"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "WBPhenotype:0000886"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0000886> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "Variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000886> "nematode phenotype"^^xsd:string)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000887> (hermaphrodite behavior variant)
 
@@ -11833,13 +11849,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000984> "posterior pigmentation variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000984> <http://purl.obolibrary.org/obo/WBPhenotype_0000786>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (blast cell physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (blast cell physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0009987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "Animals exhibit variations in any physical or chemical process required for the blast cell to carry out its normal functions or activities or be able to perceive and respond to cues, compared to control animals."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "blast cell physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "blast cell physiology abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "WBPhenotype:0000985"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "blast cell physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0000985> "blast cell physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0000985> <http://purl.obolibrary.org/obo/WBPhenotype_0000536>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000986> (epithelial cell physiology variant)
@@ -13950,14 +13967,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001209> "skiddy"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001209> <http://purl.obolibrary.org/obo/WBPhenotype_0001701>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (pericellular component physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (pericellular component physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "Animals exhibit variations in any physical or chemical process taking place in extracellular spaces within or associated with the organism, from that observed for control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "pericellular component physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "pericellular component physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "pericellular component physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "WBPhenotype:0001210"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#inSubset> <http://purl.obolibrary.org/obo/WBPhenotype_0001210> <http://purl.obolibrary.org/obo/wbphenotype#phenotype_slim_wb>)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "pericellular component physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001210> "pericellular component physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001210> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001211> (cuticle integrity variant)
@@ -14683,13 +14701,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001292> "body wall muscle physiology variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001292> <http://purl.obolibrary.org/obo/WBPhenotype_0000611>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001293> (larval physiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001293> (larval physiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson712"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "Animals exhibit variations in any physical or chemical process required for the larva to carry out its normal metabolic functions or activities or be able to perceive and respond to stimuli, compared to control animals."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "larval physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "larval physiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "larval physiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "WBPhenotype:0001293"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "larval physiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001293> "larval physiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001293> <http://purl.obolibrary.org/obo/WBPhenotype_0000576>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001294> (head bent)
@@ -14879,13 +14898,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001314> "vulval muscle variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001314> <http://purl.obolibrary.org/obo/WBPhenotype_0000282>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001315> (electrophysiology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001315> (electrophysiology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "Animals exhibit variations in the electrical properties of any of its cells or tissues compared to control."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "electrophysiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "electrophysiology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "electrophysiology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "WBPhenotype:0001315"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "electrophysiology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001315> "electrophysiology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001315> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001316> (evoked postsynaptic current variant)
@@ -15154,14 +15174,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001345> "cytoskeleton organization biogenesis variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001345> <http://purl.obolibrary.org/obo/WBPhenotype_0001344>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001346> (actin cytoskeleton dynamics variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001346> (actin cytoskeleton dynamics phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0031532"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "Any variation in the dynamic structural changes to the arrangement of constituent parts of cytoskeletal structures comprising actin filaments and their associated proteins compared to control."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "actin cytoskeleton dynamics variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "actin cytoskeleton dynamic abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "WBPhenotype:0001346"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "Possible XP."^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "actin cytoskeleton dynamics variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001346> "actin cytoskeleton dynamics phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001346> <http://purl.obolibrary.org/obo/WBPhenotype_0001587>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001347> (intestinal calcium signaling variant)
@@ -15227,13 +15248,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001353> "centration defective early emb"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001353> <http://purl.obolibrary.org/obo/WBPhenotype_0001152>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001354> (actin cytoskeleton filament morphology variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001354> (actin cytoskeleton filament morphology phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "Animals exhibit variations in the form, structure, composition or arrangement of actin, an abundant cytoskeletal protein in most cells, often linked to the plasma membrane and concentrated at cell junctions compared to control (Wormatlas)."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "actin cytoskeleton filament morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "actin cytoskeleton filament morphology abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "actin cytoskeleton filament morphology variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "WBPhenotype:0001354"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "actin cytoskeleton filament morphology variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001354> "actin cytoskeleton filament morphology phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001354> <http://purl.obolibrary.org/obo/WBPhenotype_0001587>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001355> (gonad morphology variant)
@@ -16987,13 +17009,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001546> "dauer resistance to harsh conditions variant"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001546> <http://purl.obolibrary.org/obo/WBPhenotype_0002527>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001547> (dauer metabolism variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001547> (dauer metabolism phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "Animals exhibit variations in the chemical reactions and pathways that occur during the dauer life stage, compared to control."^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "dauer metabolism abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "dauer metabolism abnormal"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "dauer metabolism variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "WBPhenotype:0001547"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "dauer metabolism variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001547> "dauer metabolism phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001547> <http://purl.obolibrary.org/obo/WBPhenotype_0002527>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001548> (dauer axial ratio variant)
@@ -17348,14 +17371,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001586> "multiple anchor cells"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001586> <http://purl.obolibrary.org/obo/WBPhenotype_0002175>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001587> (actin organization biogenesis variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001587> (actin organization biogenesis phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "GO:0030036"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2021"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "Animals exhibit variations in the formation and/or arrangement of actin, an abundant cytoskeletal protein in most cells, often linked to the plasma membrane and concentrated at cell junctions compared to control (Wormatlas)."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "actin organization biogenesis variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "actin organization biogenesis abnormal"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "WBPhenotype:0001587"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "Possible XP."^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "actin organization biogenesis variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0001587> "actin organization biogenesis phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0001587> <http://purl.obolibrary.org/obo/WBPhenotype_0001345>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001588> (microtubule organization biogenesis variant)
@@ -21946,12 +21970,13 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002117> "occurences of decapitation"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002117> <http://purl.obolibrary.org/obo/WBPhenotype_0000212>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002118> (population fitness variant)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002118> (population fitness phenotype)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00040316"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPaper00040815"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson557"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "Populations exhibit variations in the ability to survive, grow and reproduce, thus affecting the contribution to the gene pool over generations compared to control populations.  In C. elegans the fitness of a population can by assessed by measuring the rate at which E. coli is consumed."^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "population fitness variant"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "WBPhenotype:0002118"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "population fitness variant"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002118> "population fitness phenotype"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002118> <http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002119> (alternative splicing defective)
@@ -25566,13 +25591,13 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002554> "organ system phenotype"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002554> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002555> (organismal phenotype)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002555> (obsolete organismal phenotype)
 
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "A phenotype affecting the whole organism."^^xsd:string)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:WBPerson2987"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "OBSOLETE: A phenotype affecting the whole organism."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "C_elegans_phenotype_ontology"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "WBPhenotype:0002555"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "organismal phenotype"@en)
-SubClassOf(<http://purl.obolibrary.org/obo/WBPhenotype_0002555> <http://purl.obolibrary.org/obo/WBPhenotype_0000886>)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "obsolete organismal phenotype"@en)
+AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/WBPhenotype_0002555> "true"^^xsd:boolean)
 
 # Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002556> (tissue phenotype)
 

--- a/src/ontology/wbphenotype-edit.properties
+++ b/src/ontology/wbphenotype-edit.properties
@@ -1,6 +1,6 @@
-#Fri Oct 25 10:35:05 EDT 2019
+#Tue Nov 05 16:18:26 EST 2019
 jdbc.url=
 jdbc.driver=
 jdbc.user=
-jdbc.name=984dd9bd-5c43-4265-aad3-7c417ac0ee37
+jdbc.name=0044e210-536d-430d-9ff0-917fa9adc3c7
 jdbc.password=

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -1195,2723 +1195,2719 @@ Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0002573>))
 #   Classes
 ############################
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000005> (<http://purl.obolibrary.org/obo/WBPhenotype_0000005>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000005> (hyperactive egg laying)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000008> (<http://purl.obolibrary.org/obo/WBPhenotype_0000008>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000008> (anesthetic hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38867>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000009> (<http://purl.obolibrary.org/obo/WBPhenotype_0000009>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000009> (anesthetic resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000009> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38867>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000010> (<http://purl.obolibrary.org/obo/WBPhenotype_0000010>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000010> (drug hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000010> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_23888>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000011> (<http://purl.obolibrary.org/obo/WBPhenotype_0000011>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000011> (drug resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000011> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_23888>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000016> (<http://purl.obolibrary.org/obo/WBPhenotype_0000016>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000016> (aldicarb hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000017> (<http://purl.obolibrary.org/obo/WBPhenotype_0000017>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000017> (aldicarb resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_2555>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000018> (<http://purl.obolibrary.org/obo/WBPhenotype_0000018>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000018> (pharyngeal pumping increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000019> (<http://purl.obolibrary.org/obo/WBPhenotype_0000019>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000019> (pharyngeal pumping reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000022> (<http://purl.obolibrary.org/obo/WBPhenotype_0000022>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000022> (long)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000022> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000023> (<http://purl.obolibrary.org/obo/WBPhenotype_0000023>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000023> (serotonin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000024> (<http://purl.obolibrary.org/obo/WBPhenotype_0000024>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000024> (serotonin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000025> (<http://purl.obolibrary.org/obo/WBPhenotype_0000025>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000025> (blistered)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001928> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000028> (<http://purl.obolibrary.org/obo/WBPhenotype_0000028>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000028> (RNA processing variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000028> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006396>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000030> (<http://purl.obolibrary.org/obo/WBPhenotype_0000030>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000030> (growth variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000030> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000031> (<http://purl.obolibrary.org/obo/WBPhenotype_0000031>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000031> (slow growth)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000033> (<http://purl.obolibrary.org/obo/WBPhenotype_0000033>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000033> (developmental timing variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040034>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000041> (<http://purl.obolibrary.org/obo/WBPhenotype_0000041>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000041> (osmotic integrity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030104>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000042> (<http://purl.obolibrary.org/obo/WBPhenotype_0000042>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000042> (slow embryonic development)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000047> (<http://purl.obolibrary.org/obo/WBPhenotype_0000047>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000047> (gastrulation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007369>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000048> (<http://purl.obolibrary.org/obo/WBPhenotype_0000048>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000048> (hatching variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035188>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000049> (<http://purl.obolibrary.org/obo/WBPhenotype_0000049>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000049> (postembryonic development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009791>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000067> (<http://purl.obolibrary.org/obo/WBPhenotype_0000067>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000067> (organism stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000067> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006950>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000068> (<http://purl.obolibrary.org/obo/WBPhenotype_0000068>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000068> (cellular oxidative stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000068> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034599>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000071> (<http://purl.obolibrary.org/obo/WBPhenotype_0000071>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000071> (head morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000071> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000072> (<http://purl.obolibrary.org/obo/WBPhenotype_0000072>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000072> (body morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000072> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005740>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000073> (<http://purl.obolibrary.org/obo/WBPhenotype_0000073>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000073> (tail morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000073> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000075> (<http://purl.obolibrary.org/obo/WBPhenotype_0000075>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000075> (cuticle attachment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000075> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000080> (<http://purl.obolibrary.org/obo/WBPhenotype_0000080>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000080> (no anterior pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000080> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003733>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000087> (<http://purl.obolibrary.org/obo/WBPhenotype_0000087>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000087> (body wall cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000087> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006804>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000089> (<http://purl.obolibrary.org/obo/WBPhenotype_0000089>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000089> (alpha amanitin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_37415>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000092> (<http://purl.obolibrary.org/obo/WBPhenotype_0000092>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000092> (intestinal cell proliferation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000092> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008283> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005792>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000094> (<http://purl.obolibrary.org/obo/WBPhenotype_0000094>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000094> (anus development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000094> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005364>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000095> (<http://purl.obolibrary.org/obo/WBPhenotype_0000095>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000095> (M lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000095> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008439>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000096> (<http://purl.obolibrary.org/obo/WBPhenotype_0000096>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000096> (cloacal development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000096> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005774>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000097> (<http://purl.obolibrary.org/obo/WBPhenotype_0000097>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000097> (AB lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000097> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008611>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000098> (<http://purl.obolibrary.org/obo/WBPhenotype_0000098>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000098> (pharyngeal intestinal valve development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000098> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005767>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000099> (<http://purl.obolibrary.org/obo/WBPhenotype_0000099>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000099> (P lineages variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000099> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008590>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000100> (<http://purl.obolibrary.org/obo/WBPhenotype_0000100>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000100> (cell UV response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034644>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000102> (<http://purl.obolibrary.org/obo/WBPhenotype_0000102>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000102> (presynaptic vesicle cluster variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000102> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0097091>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000103> (<http://purl.obolibrary.org/obo/WBPhenotype_0000103>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000103> (gut granule development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/GO_0044840>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000104> (<http://purl.obolibrary.org/obo/WBPhenotype_0000104>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000104> (cell polarity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000104> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007163>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000105> (<http://purl.obolibrary.org/obo/WBPhenotype_0000105>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000105> (oocyte meiotic maturation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000105> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1903537>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000106> (<http://purl.obolibrary.org/obo/WBPhenotype_0000106>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000106> (inhibition of oocyte maturation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1904145>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000107> (<http://purl.obolibrary.org/obo/WBPhenotype_0000107>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000107> (inhibition of ovulation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000107> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060280>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000121> (<http://purl.obolibrary.org/obo/WBPhenotype_0000121>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000121> (translation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000121> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006412>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000124> (<http://purl.obolibrary.org/obo/WBPhenotype_0000124>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000124> (enzyme activity reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000124> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000125> (<http://purl.obolibrary.org/obo/WBPhenotype_0000125>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000125> (enzyme activity increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000125> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000127> (<http://purl.obolibrary.org/obo/WBPhenotype_0000127>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000127> (dauer recovery variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000127> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043054>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000136> (<http://purl.obolibrary.org/obo/WBPhenotype_0000136>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000136> (mRNA levels increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_33699>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000137> (<http://purl.obolibrary.org/obo/WBPhenotype_0000137>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000137> (mRNA levels reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_33699>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000142> (<http://purl.obolibrary.org/obo/WBPhenotype_0000142>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000142> (cell stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0033554>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000143> (<http://purl.obolibrary.org/obo/WBPhenotype_0000143>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000143> (organism UV response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000146> (<http://purl.obolibrary.org/obo/WBPhenotype_0000146>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000146> (organism temperature response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000146> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009266>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000147> (<http://purl.obolibrary.org/obo/WBPhenotype_0000147>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000147> (organism starvation response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000147> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042594>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000153> (<http://purl.obolibrary.org/obo/WBPhenotype_0000153>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000153> (body wall muscle contraction abnormal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000153> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0006936> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005813>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000165> (<http://purl.obolibrary.org/obo/WBPhenotype_0000165>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000165> (cell fusion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000768>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000168> (<http://purl.obolibrary.org/obo/WBPhenotype_0000168>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000168> (alae secretion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0046903> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007832>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000171> (<http://purl.obolibrary.org/obo/WBPhenotype_0000171>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000171> (cell proliferation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008283>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000172> (<http://purl.obolibrary.org/obo/WBPhenotype_0000172>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000172> (cell proliferation increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008283>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000173> (<http://purl.obolibrary.org/obo/WBPhenotype_0000173>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000173> (cell proliferation reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000173> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008283>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000174> (<http://purl.obolibrary.org/obo/WBPhenotype_0000174>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000174> (basal lamina development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000174> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005756>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000180> (<http://purl.obolibrary.org/obo/WBPhenotype_0000180>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000180> (axon morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000180> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030424>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000182> (<http://purl.obolibrary.org/obo/WBPhenotype_0000182>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000182> (apoptosis reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000183> (<http://purl.obolibrary.org/obo/WBPhenotype_0000183>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000183> (apoptosis increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000184> (<http://purl.obolibrary.org/obo/WBPhenotype_0000184>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000184> (apoptosis fails to occur)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000186> (<http://purl.obolibrary.org/obo/WBPhenotype_0000186>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000186> (oogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000186> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048599>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000190> (<http://purl.obolibrary.org/obo/WBPhenotype_0000190>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000190> (no dauer recovery)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043054>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000191> (<http://purl.obolibrary.org/obo/WBPhenotype_0000191>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000191> (organism crowding response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0090664>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000196> (<http://purl.obolibrary.org/obo/WBPhenotype_0000196>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000196> (distal tip cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006865>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000197> (<http://purl.obolibrary.org/obo/WBPhenotype_0000197>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000197> (cell induction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031129>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000199> (<http://purl.obolibrary.org/obo/WBPhenotype_0000199>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000199> (male tail sensory ray development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006941>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000200> (<http://purl.obolibrary.org/obo/WBPhenotype_0000200>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000200> (pericellular component development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/GO_0031012>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000201> (<http://purl.obolibrary.org/obo/WBPhenotype_0000201>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000201> (cuticle development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000201> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042335>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000207> (<http://purl.obolibrary.org/obo/WBPhenotype_0000207>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000207> (defecation cycle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035882>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000213> (<http://purl.obolibrary.org/obo/WBPhenotype_0000213>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000213> (zygotic development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0004422>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000214> (<http://purl.obolibrary.org/obo/WBPhenotype_0000214>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000214> (alpha amanitin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000214> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_37415>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000215> (<http://purl.obolibrary.org/obo/WBPhenotype_0000215>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000215> (no germ line)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005784>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000216> (<http://purl.obolibrary.org/obo/WBPhenotype_0000216>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000216> (cell fate specification variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000216> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001708>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000221> (<http://purl.obolibrary.org/obo/WBPhenotype_0000221>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000221> (neurotransmitter metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000221> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042133>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000222> (<http://purl.obolibrary.org/obo/WBPhenotype_0000222>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000222> (serotonin metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000222> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042428>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000223> (<http://purl.obolibrary.org/obo/WBPhenotype_0000223>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000223> (acetylcholine metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008291>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000229> (<http://purl.obolibrary.org/obo/WBPhenotype_0000229>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000229> (small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000229> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000233> (<http://purl.obolibrary.org/obo/WBPhenotype_0000233>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000233> (dopamine metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042417>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000237> (<http://purl.obolibrary.org/obo/WBPhenotype_0000237>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000237> (foraging hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060756>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000238> (<http://purl.obolibrary.org/obo/WBPhenotype_0000238>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000238> (foraging reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060756>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000244> (<http://purl.obolibrary.org/obo/WBPhenotype_0000244>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000244> (apoptotic arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000250> (<http://purl.obolibrary.org/obo/WBPhenotype_0000250>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000250> (octopamine metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0046333>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000252> (<http://purl.obolibrary.org/obo/WBPhenotype_0000252>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000252> (caffeine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000256> (<http://purl.obolibrary.org/obo/WBPhenotype_0000256>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000256> (amphid neuron morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005391>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000257> (<http://purl.obolibrary.org/obo/WBPhenotype_0000257>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000257> (phasmid neuron morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005425>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000258> (<http://purl.obolibrary.org/obo/WBPhenotype_0000258>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000258> (cell secretion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032940>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000262> (<http://purl.obolibrary.org/obo/WBPhenotype_0000262>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000262> (axoneme morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005930>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000263> (<http://purl.obolibrary.org/obo/WBPhenotype_0000263>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000263> (axoneme short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000263> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005930>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000276> (<http://purl.obolibrary.org/obo/WBPhenotype_0000276>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000276> (organism X ray response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010165>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000277> (<http://purl.obolibrary.org/obo/WBPhenotype_0000277>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000277> (rhythm slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048511>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000278> (<http://purl.obolibrary.org/obo/WBPhenotype_0000278>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000278> (body region pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000278> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005738>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000289> (<http://purl.obolibrary.org/obo/WBPhenotype_0000289>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000289> (uterus morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006760>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000290> (<http://purl.obolibrary.org/obo/WBPhenotype_0000290>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000290> (sperm absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000291> (<http://purl.obolibrary.org/obo/WBPhenotype_0000291>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000291> (no oocytes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006797>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000292> (<http://purl.obolibrary.org/obo/WBPhenotype_0000292>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000292> (organ system pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005746>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000293> (<http://purl.obolibrary.org/obo/WBPhenotype_0000293>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000293> (alimentary system pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000299> (<http://purl.obolibrary.org/obo/WBPhenotype_0000299>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000299> (sensillum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000299> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000300> (<http://purl.obolibrary.org/obo/WBPhenotype_0000300>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000300> (amphid sheath cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006754>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000308> (<http://purl.obolibrary.org/obo/WBPhenotype_0000308>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000308> (dauer development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000308> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040024>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000310> (<http://purl.obolibrary.org/obo/WBPhenotype_0000310>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000310> (cilia absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000318> (<http://purl.obolibrary.org/obo/WBPhenotype_0000318>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000318> (cell cycle delayed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000318> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000319> (<http://purl.obolibrary.org/obo/WBPhenotype_0000319>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000319> (large)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000319> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000321> (<http://purl.obolibrary.org/obo/WBPhenotype_0000321>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000321> (nose morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008426>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000324> (<http://purl.obolibrary.org/obo/WBPhenotype_0000324>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000324> (short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000325> (<http://purl.obolibrary.org/obo/WBPhenotype_0000325>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000325> (arecoline hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_2814>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000326> (<http://purl.obolibrary.org/obo/WBPhenotype_0000326>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000326> (arecoline resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_2814>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000332> (<http://purl.obolibrary.org/obo/WBPhenotype_0000332>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000332> (inhibitors of sodium potassium ATPase hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000332> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_63510>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000340> (<http://purl.obolibrary.org/obo/WBPhenotype_0000340>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000340> (imipramine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000341> (<http://purl.obolibrary.org/obo/WBPhenotype_0000341>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000341> (imipramine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000341> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_47499>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000347> (<http://purl.obolibrary.org/obo/WBPhenotype_0000347>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000347> (rectal development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000347> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005773>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000351> (<http://purl.obolibrary.org/obo/WBPhenotype_0000351>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000351> (failure to hatch)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035188>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000354> (<http://purl.obolibrary.org/obo/WBPhenotype_0000354>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000354> (cell differentiation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000354> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030154>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000356> (<http://purl.obolibrary.org/obo/WBPhenotype_0000356>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000356> (spermatogenesis delayed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000356> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007283>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000359> (<http://purl.obolibrary.org/obo/WBPhenotype_0000359>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000359> (tunicamycin response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1904576>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000363> (<http://purl.obolibrary.org/obo/WBPhenotype_0000363>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000363> (cell division slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000372> (<http://purl.obolibrary.org/obo/WBPhenotype_0000372>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000372> (no polar body formation)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000372> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008429>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000381> (<http://purl.obolibrary.org/obo/WBPhenotype_0000381>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000381> (serotonin reuptake inhibitor resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000381> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_50949>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000382> (<http://purl.obolibrary.org/obo/WBPhenotype_0000382>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000382> (serotonin reuptake inhibitor hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000382> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_50949>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000384> (<http://purl.obolibrary.org/obo/WBPhenotype_0000384>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000384> (axon guidance variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000384> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007411>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000385> (<http://purl.obolibrary.org/obo/WBPhenotype_0000385>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000385> (sperm excess)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000388> (<http://purl.obolibrary.org/obo/WBPhenotype_0000388>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000388> (sperm morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000388> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006798>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000393> (<http://purl.obolibrary.org/obo/WBPhenotype_0000393>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000393> (cell migration failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016477>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000395> (<http://purl.obolibrary.org/obo/WBPhenotype_0000395>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000395> (no differentiated gametes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000395> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CL_0000300>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000399> (<http://purl.obolibrary.org/obo/WBPhenotype_0000399>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000399> (somatic gonad development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000399> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005785>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000401> (<http://purl.obolibrary.org/obo/WBPhenotype_0000401>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000401> (no uterus)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000401> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006760>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000404> (<http://purl.obolibrary.org/obo/WBPhenotype_0000404>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000404> (delayed hatching)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035188>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000405> (<http://purl.obolibrary.org/obo/WBPhenotype_0000405>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000405> (giant oocytes)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006797>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000410> (<http://purl.obolibrary.org/obo/WBPhenotype_0000410>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000410> (no defecation cycle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035882>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000415> (<http://purl.obolibrary.org/obo/WBPhenotype_0000415>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000415> (necrotic cell death variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0070265>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000416> (<http://purl.obolibrary.org/obo/WBPhenotype_0000416>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000416> (yolk synthesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000416> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007296>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000417> (<http://purl.obolibrary.org/obo/WBPhenotype_0000417>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000417> (cell division failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000420> (<http://purl.obolibrary.org/obo/WBPhenotype_0000420>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000420> (levamisole hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000420> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6432>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000421> (<http://purl.obolibrary.org/obo/WBPhenotype_0000421>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000421> (levamisole resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6432>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000427> (<http://purl.obolibrary.org/obo/WBPhenotype_0000427>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000427> (no cuticle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000433> (<http://purl.obolibrary.org/obo/WBPhenotype_0000433>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000433> (DNA synthesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000433> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006260>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000436> (<http://purl.obolibrary.org/obo/WBPhenotype_0000436>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000436> (protein subcellular localization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000436> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034613>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000440> (<http://purl.obolibrary.org/obo/WBPhenotype_0000440>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000440> (excretory canals long)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005775>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000441> (<http://purl.obolibrary.org/obo/WBPhenotype_0000441>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000441> (tail rounded)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000441> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000442> (<http://purl.obolibrary.org/obo/WBPhenotype_0000442>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000442> (larval development retarded)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000443> (<http://purl.obolibrary.org/obo/WBPhenotype_0000443>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000443> (spicule morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000443> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005312>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000460> (<http://purl.obolibrary.org/obo/WBPhenotype_0000460>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000460> (paraquat response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1901562>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000461> (<http://purl.obolibrary.org/obo/WBPhenotype_0000461>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000461> (paraquat resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000461> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_34905>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000462> (<http://purl.obolibrary.org/obo/WBPhenotype_0000462>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000462> (paraquat hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_34905>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000474> (<http://purl.obolibrary.org/obo/WBPhenotype_0000474>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000474> (muscle attachment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000474> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016203>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000481> (<http://purl.obolibrary.org/obo/WBPhenotype_0000481>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000481> (negative chemotaxis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000481> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050919>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000486> (<http://purl.obolibrary.org/obo/WBPhenotype_0000486>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000486> (colchicine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000486> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_23359>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000487> (<http://purl.obolibrary.org/obo/WBPhenotype_0000487>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000487> (colchicine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000487> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_23359>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000488> (<http://purl.obolibrary.org/obo/WBPhenotype_0000488>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000488> (chloroquine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000488> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_3638>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000489> (<http://purl.obolibrary.org/obo/WBPhenotype_0000489>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000489> (chloroquine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000489> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_3638>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000491> (<http://purl.obolibrary.org/obo/WBPhenotype_0000491>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000491> (isthmus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000491> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003734>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000492> (<http://purl.obolibrary.org/obo/WBPhenotype_0000492>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000492> (corpus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003733>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000493> (<http://purl.obolibrary.org/obo/WBPhenotype_0000493>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000493> (metacorpus morphology defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003711>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000495> (<http://purl.obolibrary.org/obo/WBPhenotype_0000495>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000495> (ray ectopic)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000497> (<http://purl.obolibrary.org/obo/WBPhenotype_0000497>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000497> (organism gamma ray response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010332>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000500> (<http://purl.obolibrary.org/obo/WBPhenotype_0000500>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000500> (acetylcholinesterase inhibitor hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000503> (<http://purl.obolibrary.org/obo/WBPhenotype_0000503>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000503> (endoreduplication variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000503> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042023>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000504> (<http://purl.obolibrary.org/obo/WBPhenotype_0000504>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000504> (nuclear division variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000504> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000280>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000505> (<http://purl.obolibrary.org/obo/WBPhenotype_0000505>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000505> (male ray morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000505> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000511> (<http://purl.obolibrary.org/obo/WBPhenotype_0000511>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000511> (nuclear positioning variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007097>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000515> (<http://purl.obolibrary.org/obo/WBPhenotype_0000515>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000515> (ventral nerve cord development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000515> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005829>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000517> (<http://purl.obolibrary.org/obo/WBPhenotype_0000517>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000517> (behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007610>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000518> (<http://purl.obolibrary.org/obo/WBPhenotype_0000518>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000518> (development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000518> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (<http://purl.obolibrary.org/obo/WBPhenotype_0000519>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000519> (physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008150>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000521> (<http://purl.obolibrary.org/obo/WBPhenotype_0000521>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000521> (pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000521> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000523> (<http://purl.obolibrary.org/obo/WBPhenotype_0000523>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000523> (chemical response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042221>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000524> (<http://purl.obolibrary.org/obo/WBPhenotype_0000524>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000524> (bleach response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000524> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1901530>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000526> (<http://purl.obolibrary.org/obo/WBPhenotype_0000526>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000526> (cell pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000526> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000528> (<http://purl.obolibrary.org/obo/WBPhenotype_0000528>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000528> (body region development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000528> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005738>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000529> (<http://purl.obolibrary.org/obo/WBPhenotype_0000529>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000529> (cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000529> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048468>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000530> (<http://purl.obolibrary.org/obo/WBPhenotype_0000530>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000530> (organ system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000530> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005746>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000531> (<http://purl.obolibrary.org/obo/WBPhenotype_0000531>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000531> (organism development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000531> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0007833>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000532> (<http://purl.obolibrary.org/obo/WBPhenotype_0000532>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000532> (body region morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005738>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000533> (<http://purl.obolibrary.org/obo/WBPhenotype_0000533>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000533> (cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000533> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000534> (<http://purl.obolibrary.org/obo/WBPhenotype_0000534>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000534> (organ system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000534> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005746>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (<http://purl.obolibrary.org/obo/WBPhenotype_0000536>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000536> (cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0004017>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000539> (<http://purl.obolibrary.org/obo/WBPhenotype_0000539>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000539> (dorsal nerve cord development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006750>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000540> (<http://purl.obolibrary.org/obo/WBPhenotype_0000540>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000540> (muscle arm development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000540> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/GO_0036194>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000559> (<http://purl.obolibrary.org/obo/WBPhenotype_0000559>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000559> (calcium channel modulator hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38808>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000560> (<http://purl.obolibrary.org/obo/WBPhenotype_0000560>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000560> (calcium channel modulator resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000560> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38808>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000574> (<http://purl.obolibrary.org/obo/WBPhenotype_0000574>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000574> (excretory canal short)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005775>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (<http://purl.obolibrary.org/obo/WBPhenotype_0000575>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000575> (organ system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005746>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (<http://purl.obolibrary.org/obo/WBPhenotype_0000576>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000576> (organism physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007833>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000578> (<http://purl.obolibrary.org/obo/WBPhenotype_0000578>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000578> (body axis development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000578> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005768>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000581> (<http://purl.obolibrary.org/obo/WBPhenotype_0000581>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000581> (body axis morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000581> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005768>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000584> (<http://purl.obolibrary.org/obo/WBPhenotype_0000584>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000584> (synaptic transmission variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007268>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000586> (<http://purl.obolibrary.org/obo/WBPhenotype_0000586>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000586> (bleach hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_29222>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000593> (<http://purl.obolibrary.org/obo/WBPhenotype_0000593>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000593> (copper hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000593> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28694>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000594> (<http://purl.obolibrary.org/obo/WBPhenotype_0000594>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000594> (cell migration variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016477>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000598> (<http://purl.obolibrary.org/obo/WBPhenotype_0000598>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000598> (alimentary system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000599> (<http://purl.obolibrary.org/obo/WBPhenotype_0000599>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000599> (coelomic system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005749>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000600> (<http://purl.obolibrary.org/obo/WBPhenotype_0000600>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000600> (epithelial system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000600> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005730>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000601> (<http://purl.obolibrary.org/obo/WBPhenotype_0000601>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000601> (excretory secretory system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000601> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005736>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000603> (<http://purl.obolibrary.org/obo/WBPhenotype_0000603>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000603> (muscle system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000603> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005737>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000604> (<http://purl.obolibrary.org/obo/WBPhenotype_0000604>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000604> (nervous system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005735>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000605> (<http://purl.obolibrary.org/obo/WBPhenotype_0000605>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000605> (reproductive system morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000605> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005747>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000606> (<http://purl.obolibrary.org/obo/WBPhenotype_0000606>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000606> (alimentary system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005748>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000607> (<http://purl.obolibrary.org/obo/WBPhenotype_0000607>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000607> (coelomic system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000607> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005749>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000608> (<http://purl.obolibrary.org/obo/WBPhenotype_0000608>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000608> (epithelial system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005730>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000609> (<http://purl.obolibrary.org/obo/WBPhenotype_0000609>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000609> (excretory secretory system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006850>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000610> (<http://purl.obolibrary.org/obo/WBPhenotype_0000610>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000610> (excretory system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005736>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000611> (<http://purl.obolibrary.org/obo/WBPhenotype_0000611>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000611> (muscle system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005737>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000612> (<http://purl.obolibrary.org/obo/WBPhenotype_0000612>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000612> (nervous system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005735>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000613> (<http://purl.obolibrary.org/obo/WBPhenotype_0000613>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000613> (reproductive system physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000613> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005747>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000614> (<http://purl.obolibrary.org/obo/WBPhenotype_0000614>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000614> (GLR development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000614> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005176>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000615> (<http://purl.obolibrary.org/obo/WBPhenotype_0000615>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000615> (cilia morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000615> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005929>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000616> (<http://purl.obolibrary.org/obo/WBPhenotype_0000616>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000616> (synapse morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045202>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000617> (<http://purl.obolibrary.org/obo/WBPhenotype_0000617>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000617> (alimentary system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005748>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000618> (<http://purl.obolibrary.org/obo/WBPhenotype_0000618>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000618> (coelomic system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000618> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005749>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000619> (<http://purl.obolibrary.org/obo/WBPhenotype_0000619>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000619> (epithelial system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000619> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005730>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000620> (<http://purl.obolibrary.org/obo/WBPhenotype_0000620>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000620> (excretory secretory system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000620> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006850>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000621> (<http://purl.obolibrary.org/obo/WBPhenotype_0000621>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000621> (excretory system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000621> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005736>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000622> (<http://purl.obolibrary.org/obo/WBPhenotype_0000622>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000622> (muscle system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000622> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005737>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000623> (<http://purl.obolibrary.org/obo/WBPhenotype_0000623>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000623> (nervous system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007399>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000624> (<http://purl.obolibrary.org/obo/WBPhenotype_0000624>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000624> (reproductive system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005747>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000625> (<http://purl.obolibrary.org/obo/WBPhenotype_0000625>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000625> (synaptogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000625> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007416>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000626> (<http://purl.obolibrary.org/obo/WBPhenotype_0000626>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000626> (habituation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0046959>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000627> (<http://purl.obolibrary.org/obo/WBPhenotype_0000627>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000627> (anesthetic response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000627> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0072347>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000631> (<http://purl.obolibrary.org/obo/WBPhenotype_0000631>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000631> (drug response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000631> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042493>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000632> (<http://purl.obolibrary.org/obo/WBPhenotype_0000632>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000632> (axon fasciculation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007413>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000634> (<http://purl.obolibrary.org/obo/WBPhenotype_0000634>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000634> (pharyngeal pumping variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000634> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000635> (<http://purl.obolibrary.org/obo/WBPhenotype_0000635>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000635> (positive chemotaxis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050918>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000640> (<http://purl.obolibrary.org/obo/WBPhenotype_0000640>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000640> (egg laying variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000640> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000642> (<http://purl.obolibrary.org/obo/WBPhenotype_0000642>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000642> (hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000646> (<http://purl.obolibrary.org/obo/WBPhenotype_0000646>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000646> (sluggish)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000647> (<http://purl.obolibrary.org/obo/WBPhenotype_0000647>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000647> (copulation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000647> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007620>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000648> (<http://purl.obolibrary.org/obo/WBPhenotype_0000648>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000648> (male mating variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060179>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000649> (<http://purl.obolibrary.org/obo/WBPhenotype_0000649>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000649> (vulva location variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034608>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000650> (<http://purl.obolibrary.org/obo/WBPhenotype_0000650>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000650> (defecation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030421>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000654> (<http://purl.obolibrary.org/obo/WBPhenotype_0000654>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000654> (synaptic vesicle exocytosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000654> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016079>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000655> (<http://purl.obolibrary.org/obo/WBPhenotype_0000655>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000655> (GABA synaptic transmission variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051932>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000656> (<http://purl.obolibrary.org/obo/WBPhenotype_0000656>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000656> (acetylcholine synaptic transmission variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007271>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000658> (<http://purl.obolibrary.org/obo/WBPhenotype_0000658>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000658> (neuromuscular synaptic transmission variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007274>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000659> (<http://purl.obolibrary.org/obo/WBPhenotype_0000659>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000659> (feeding behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000659> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007631>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000662> (<http://purl.obolibrary.org/obo/WBPhenotype_0000662>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000662> (foraging behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000662> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060756>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000666> (<http://purl.obolibrary.org/obo/WBPhenotype_0000666>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000666> (ovulation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000666> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030728>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000670> (<http://purl.obolibrary.org/obo/WBPhenotype_0000670>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000670> (spermatogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000670> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007283>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000671> (<http://purl.obolibrary.org/obo/WBPhenotype_0000671>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000671> (resistant to copper)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28694>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000674> (<http://purl.obolibrary.org/obo/WBPhenotype_0000674>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000674> (slow development)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000674> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000684> (<http://purl.obolibrary.org/obo/WBPhenotype_0000684>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000684> (fewer germ cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006796>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000686> (<http://purl.obolibrary.org/obo/WBPhenotype_0000686>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000686> (organism ionizing radiation response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000686> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010212>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000691> (<http://purl.obolibrary.org/obo/WBPhenotype_0000691>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000691> (gonad development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008406>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000695> (<http://purl.obolibrary.org/obo/WBPhenotype_0000695>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000695> (vulva morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000695> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000698> (<http://purl.obolibrary.org/obo/WBPhenotype_0000698>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000698> (vulvaless)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000699> (<http://purl.obolibrary.org/obo/WBPhenotype_0000699>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000699> (vulva development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000699> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040025>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000700> (<http://purl.obolibrary.org/obo/WBPhenotype_0000700>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000700> (multivulva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000700> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000704> (<http://purl.obolibrary.org/obo/WBPhenotype_0000704>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000704> (excretory canal morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000704> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005775>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000705> (<http://purl.obolibrary.org/obo/WBPhenotype_0000705>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000705> (intestinal cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000705> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005792>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000707> (<http://purl.obolibrary.org/obo/WBPhenotype_0000707>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000707> (pharyngeal development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000707> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060465>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000708> (<http://purl.obolibrary.org/obo/WBPhenotype_0000708>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000708> (intestinal development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000708> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048565>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000709> (<http://purl.obolibrary.org/obo/WBPhenotype_0000709>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000709> (pharyngeal morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000709> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000710> (<http://purl.obolibrary.org/obo/WBPhenotype_0000710>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000710> (intestinal morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000710> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000712> (<http://purl.obolibrary.org/obo/WBPhenotype_0000712>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000712> (germ cell ionizing radiation response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000712> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0071479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006796>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000715> (<http://purl.obolibrary.org/obo/WBPhenotype_0000715>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000715> (muscle excess)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000715> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000717> (<http://purl.obolibrary.org/obo/WBPhenotype_0000717>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000717> (gene expression variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000717> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010467>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000718> (<http://purl.obolibrary.org/obo/WBPhenotype_0000718>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000718> (dosage compensation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000718> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007549>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000722> (<http://purl.obolibrary.org/obo/WBPhenotype_0000722>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000722> (nucleolus variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000722> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005730>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000724> (<http://purl.obolibrary.org/obo/WBPhenotype_0000724>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000724> (protein secretion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000724> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009306>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000725> (<http://purl.obolibrary.org/obo/WBPhenotype_0000725>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000725> (lipid metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000725> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006629>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000727> (<http://purl.obolibrary.org/obo/WBPhenotype_0000727>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000727> (enzyme activity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000727> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0003824>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000728> (<http://purl.obolibrary.org/obo/WBPhenotype_0000728>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000728> (exocytosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000728> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006887>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000729> (<http://purl.obolibrary.org/obo/WBPhenotype_0000729>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000729> (cell death variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000729> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008219>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000730> (<http://purl.obolibrary.org/obo/WBPhenotype_0000730>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000730> (apoptosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000730> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000732> (<http://purl.obolibrary.org/obo/WBPhenotype_0000732>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000732> (DNA metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000732> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006259>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000734> (<http://purl.obolibrary.org/obo/WBPhenotype_0000734>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000734> (hypodermal cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000734> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007846>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000736> (<http://purl.obolibrary.org/obo/WBPhenotype_0000736>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000736> (autophagy variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000736> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006914>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000738> (<http://purl.obolibrary.org/obo/WBPhenotype_0000738>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000738> (organism environmental stimulus response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000738> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009605>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000740> (<http://purl.obolibrary.org/obo/WBPhenotype_0000740>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000740> (cell cycle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000740> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000741> (<http://purl.obolibrary.org/obo/WBPhenotype_0000741>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000741> (DNA damage checkpoint variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000741> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000077>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000742> (<http://purl.obolibrary.org/obo/WBPhenotype_0000742>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000742> (DNA recombination variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000742> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006310>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000746> (<http://purl.obolibrary.org/obo/WBPhenotype_0000746>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000746> (cell division variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000746> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000749> (<http://purl.obolibrary.org/obo/WBPhenotype_0000749>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000749> (embryonic development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000749> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000750> (<http://purl.obolibrary.org/obo/WBPhenotype_0000750>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000750> (larval development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002164>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000763> (<http://purl.obolibrary.org/obo/WBPhenotype_0000763>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000763> (embryonic cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007028>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000770> (<http://purl.obolibrary.org/obo/WBPhenotype_0000770>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000770> (embryonic cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000770> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007028>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000773> (<http://purl.obolibrary.org/obo/WBPhenotype_0000773>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000773> (chromosome segregation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000773> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000774> (<http://purl.obolibrary.org/obo/WBPhenotype_0000774>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000774> (gametogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000774> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007276>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000775> (<http://purl.obolibrary.org/obo/WBPhenotype_0000775>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000775> (meiosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000775> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051321>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000789> (<http://purl.obolibrary.org/obo/WBPhenotype_0000789>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000789> (fluoxetine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000789> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_5118>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000790> (<http://purl.obolibrary.org/obo/WBPhenotype_0000790>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000790> (fluoxetine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000790> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_5118>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000805> (<http://purl.obolibrary.org/obo/WBPhenotype_0000805>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000805> (tail development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000805> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005741>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000810> (<http://purl.obolibrary.org/obo/WBPhenotype_0000810>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000810> (blast cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000810> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006783>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000811> (<http://purl.obolibrary.org/obo/WBPhenotype_0000811>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000811> (epithelial cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000811> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0002064>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000812> (<http://purl.obolibrary.org/obo/WBPhenotype_0000812>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000812> (germ cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000812> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007281>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000813> (<http://purl.obolibrary.org/obo/WBPhenotype_0000813>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000813> (gland cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000813> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0003670>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000814> (<http://purl.obolibrary.org/obo/WBPhenotype_0000814>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000814> (marginal cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000814> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0003673>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000815> (<http://purl.obolibrary.org/obo/WBPhenotype_0000815>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000815> (muscle cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000815> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0055001>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000816> (<http://purl.obolibrary.org/obo/WBPhenotype_0000816>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000816> (neuron development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000816> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048666>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000817> (<http://purl.obolibrary.org/obo/WBPhenotype_0000817>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000817> (uterine vulval cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000817> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006790>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000818> (<http://purl.obolibrary.org/obo/WBPhenotype_0000818>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000818> (adult behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000818> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030534>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000822> (<http://purl.obolibrary.org/obo/WBPhenotype_0000822>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000822> (sex determination variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000822> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007530>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000829> (<http://purl.obolibrary.org/obo/WBPhenotype_0000829>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000829> (Q lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000829> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008593>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000830> (<http://purl.obolibrary.org/obo/WBPhenotype_0000830>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000830> (B lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000830> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008608>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000832> (<http://purl.obolibrary.org/obo/WBPhenotype_0000832>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000832> (C lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000832> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008588>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000834> (<http://purl.obolibrary.org/obo/WBPhenotype_0000834>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000834> (E lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005208>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000846> (<http://purl.obolibrary.org/obo/WBPhenotype_0000846>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000846> (presynaptic region physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000846> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/GO_0098793>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000848> (<http://purl.obolibrary.org/obo/WBPhenotype_0000848>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000848> (developmental delay)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000848> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032502>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000849> (<http://purl.obolibrary.org/obo/WBPhenotype_0000849>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000849> (amphid physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000849> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005391>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000851> (<http://purl.obolibrary.org/obo/WBPhenotype_0000851>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000851> (ciliated neuron physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000851> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006816>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000852> (<http://purl.obolibrary.org/obo/WBPhenotype_0000852>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000852> (coelomocyte development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000852> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005751>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000853> (<http://purl.obolibrary.org/obo/WBPhenotype_0000853>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000853> (intraflagellar transport variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000853> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000855> (<http://purl.obolibrary.org/obo/WBPhenotype_0000855>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000855> (pseudocoelom development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000855> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005745>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000856> (<http://purl.obolibrary.org/obo/WBPhenotype_0000856>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000856> (excretory gland cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000856> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005776>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000857> (<http://purl.obolibrary.org/obo/WBPhenotype_0000857>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000857> (excretory cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000857> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005812>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000858> (<http://purl.obolibrary.org/obo/WBPhenotype_0000858>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000858> (excretory duct cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000858> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0004540>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000859> (<http://purl.obolibrary.org/obo/WBPhenotype_0000859>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000859> (excretory socket cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000859> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0004534>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000860> (<http://purl.obolibrary.org/obo/WBPhenotype_0000860>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000860> (nonstriated muscle development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000860> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005780>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000861> (<http://purl.obolibrary.org/obo/WBPhenotype_0000861>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000861> (body wall muscle development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000861> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006804>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000865> (<http://purl.obolibrary.org/obo/WBPhenotype_0000865>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000865> (amphid sheath cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000865> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006754>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000867> (<http://purl.obolibrary.org/obo/WBPhenotype_0000867>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000867> (embryonic arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000867> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009790>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000873> (<http://purl.obolibrary.org/obo/WBPhenotype_0000873>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000873> (G1 checkpoint variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000873> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0044819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000874> (<http://purl.obolibrary.org/obo/WBPhenotype_0000874>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000874> (G2 checkpoint variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000874> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0044818>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000875> (<http://purl.obolibrary.org/obo/WBPhenotype_0000875>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000875> (S phase checkpoint variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031573>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000876> (<http://purl.obolibrary.org/obo/WBPhenotype_0000876>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000876> (organism osmotic stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000876> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006970>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000877> (<http://purl.obolibrary.org/obo/WBPhenotype_0000877>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000877> (amphid sheath cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000877> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006754>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000878> (<http://purl.obolibrary.org/obo/WBPhenotype_0000878>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000878> (chemosensory neuron development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005837>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000879> (<http://purl.obolibrary.org/obo/WBPhenotype_0000879>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000879> (telomere length regulation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000879> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1904356>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000880> (<http://purl.obolibrary.org/obo/WBPhenotype_0000880>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000880> (axon development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000880> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0061564>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000882> (<http://purl.obolibrary.org/obo/WBPhenotype_0000882>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000882> (dendrite development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000882> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016358>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000883> (<http://purl.obolibrary.org/obo/WBPhenotype_0000883>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000883> (nerve ring development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000883> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006749>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000884> (<http://purl.obolibrary.org/obo/WBPhenotype_0000884>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000884> (AWB morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000884> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005671>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000885> (<http://purl.obolibrary.org/obo/WBPhenotype_0000885>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000885> (engulfment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000885> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043652>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000898> (<http://purl.obolibrary.org/obo/WBPhenotype_0000898>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000898> (blast cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000898> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006783>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000899> (<http://purl.obolibrary.org/obo/WBPhenotype_0000899>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000899> (epithelial cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000899> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003672>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000900> (<http://purl.obolibrary.org/obo/WBPhenotype_0000900>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000900> (germ cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000900> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006796>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000901> (<http://purl.obolibrary.org/obo/WBPhenotype_0000901>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000901> (gland cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000901> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003670>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000902> (<http://purl.obolibrary.org/obo/WBPhenotype_0000902>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000902> (intestinal cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005792>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000903> (<http://purl.obolibrary.org/obo/WBPhenotype_0000903>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000903> (marginal cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000903> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003673>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000904> (<http://purl.obolibrary.org/obo/WBPhenotype_0000904>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000904> (muscle cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000904> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000905> (<http://purl.obolibrary.org/obo/WBPhenotype_0000905>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000905> (neuron morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000905> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000907> (<http://purl.obolibrary.org/obo/WBPhenotype_0000907>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000907> (anus morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000907> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005364>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000908> (<http://purl.obolibrary.org/obo/WBPhenotype_0000908>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000908> (cloacal morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000908> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005774>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000909> (<http://purl.obolibrary.org/obo/WBPhenotype_0000909>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000909> (pharyngeal intestinal valve morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000909> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005767>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000910> (<http://purl.obolibrary.org/obo/WBPhenotype_0000910>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000910> (rectal morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000910> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005773>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000911> (<http://purl.obolibrary.org/obo/WBPhenotype_0000911>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000911> (coelomocyte morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005751>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000913> (<http://purl.obolibrary.org/obo/WBPhenotype_0000913>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000913> (basal lamina morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000913> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005604>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000914> (<http://purl.obolibrary.org/obo/WBPhenotype_0000914>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000914> (excretory gland cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000914> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005776>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000916> (<http://purl.obolibrary.org/obo/WBPhenotype_0000916>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000916> (excretory cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000916> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005812>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000917> (<http://purl.obolibrary.org/obo/WBPhenotype_0000917>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000917> (excretory duct cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000917> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004540>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000918> (<http://purl.obolibrary.org/obo/WBPhenotype_0000918>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000918> (excretory socket cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000918> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004534>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000921> (<http://purl.obolibrary.org/obo/WBPhenotype_0000921>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000921> (striated muscle development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000921> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005779>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000922> (<http://purl.obolibrary.org/obo/WBPhenotype_0000922>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000922> (male longitudinal muscle development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000922> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006909>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000923> (<http://purl.obolibrary.org/obo/WBPhenotype_0000923>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000923> (nonstriated muscle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000923> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005780>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000924> (<http://purl.obolibrary.org/obo/WBPhenotype_0000924>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000924> (striated muscle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000924> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005779>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000926> (<http://purl.obolibrary.org/obo/WBPhenotype_0000926>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000926> (body wall muscle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000926> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005813>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000927> (<http://purl.obolibrary.org/obo/WBPhenotype_0000927>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000927> (male longitudinal muscle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000927> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006909>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000928> (<http://purl.obolibrary.org/obo/WBPhenotype_0000928>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000928> (male physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000928> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007850>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000929> (<http://purl.obolibrary.org/obo/WBPhenotype_0000929>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000929> (hermaphrodite physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000929> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0007849>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000930> (<http://purl.obolibrary.org/obo/WBPhenotype_0000930>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000930> (sexually dimorphic development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000930> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005752>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000932> (<http://purl.obolibrary.org/obo/WBPhenotype_0000932>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000932> (bis phenol A hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000932> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_33216>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000933> (<http://purl.obolibrary.org/obo/WBPhenotype_0000933>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000933> (MS lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000933> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008627>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000935> (<http://purl.obolibrary.org/obo/WBPhenotype_0000935>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000935> (D lineage variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000935> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0008589>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000942> (<http://purl.obolibrary.org/obo/WBPhenotype_0000942>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000942> (accessory cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000942> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005762>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000943> (<http://purl.obolibrary.org/obo/WBPhenotype_0000943>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000943> (ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000943> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005189>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000944> (<http://purl.obolibrary.org/obo/WBPhenotype_0000944>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000944> (neurite development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000944> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031175>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000945> (<http://purl.obolibrary.org/obo/WBPhenotype_0000945>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000945> (neuropil development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000945> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/UBERON_0002606>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000946> (<http://purl.obolibrary.org/obo/WBPhenotype_0000946>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000946> (pharyngeal nervous system development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005440>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000948> (<http://purl.obolibrary.org/obo/WBPhenotype_0000948>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000948> (cuticle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000948> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000949> (<http://purl.obolibrary.org/obo/WBPhenotype_0000949>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000949> (pseudocoelom morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000949> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005745>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000950> (<http://purl.obolibrary.org/obo/WBPhenotype_0000950>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000950> (neuronal sheath cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000950> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005811>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000951> (<http://purl.obolibrary.org/obo/WBPhenotype_0000951>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000951> (socket cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000951> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005750>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000952> (<http://purl.obolibrary.org/obo/WBPhenotype_0000952>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000952> (anterior ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000952> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005375>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000953> (<http://purl.obolibrary.org/obo/WBPhenotype_0000953>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000953> (dorsal ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000953> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005214>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000954> (<http://purl.obolibrary.org/obo/WBPhenotype_0000954>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000954> (dorsorectal ganglia development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000954> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005212>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000955> (<http://purl.obolibrary.org/obo/WBPhenotype_0000955>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000955> (lateral ganglia development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000955> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005105>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000956> (<http://purl.obolibrary.org/obo/WBPhenotype_0000956>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000956> (lumbar ganglia development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000956> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005830>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000957> (<http://purl.obolibrary.org/obo/WBPhenotype_0000957>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000957> (posterior lateral ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000957> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005465>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000958> (<http://purl.obolibrary.org/obo/WBPhenotype_0000958>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000958> (preanal ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000958> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005448>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000959> (<http://purl.obolibrary.org/obo/WBPhenotype_0000959>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000959> (retrovesicular ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000959> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005656>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000960> (<http://purl.obolibrary.org/obo/WBPhenotype_0000960>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000960> (ventral ganglion development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000960> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005298>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000963> (<http://purl.obolibrary.org/obo/WBPhenotype_0000963>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000963> (male pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000963> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0002247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000964> (<http://purl.obolibrary.org/obo/WBPhenotype_0000964>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000964> (DMPP resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000964> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_4290>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000968> (<http://purl.obolibrary.org/obo/WBPhenotype_0000968>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000968> (tail spike variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000968> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006979>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000969> (<http://purl.obolibrary.org/obo/WBPhenotype_0000969>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000969> (accessory cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000969> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005762>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000972> (<http://purl.obolibrary.org/obo/WBPhenotype_0000972>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000972> (neuronal sheath cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000972> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005811>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000973> (<http://purl.obolibrary.org/obo/WBPhenotype_0000973>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000973> (homologous recombination increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000973> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035825>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000974> (<http://purl.obolibrary.org/obo/WBPhenotype_0000974>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000974> (accessory cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000974> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005762>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000975> (<http://purl.obolibrary.org/obo/WBPhenotype_0000975>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000975> (neuronal sheath cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000975> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005811>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000977> (<http://purl.obolibrary.org/obo/WBPhenotype_0000977>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000977> (somatic gonad morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000977> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005785>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000978> (<http://purl.obolibrary.org/obo/WBPhenotype_0000978>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000978> (spermatheca physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005319>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000981> (<http://purl.obolibrary.org/obo/WBPhenotype_0000981>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000981> (spermatocyte meiosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000981> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_1903046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006799>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (<http://purl.obolibrary.org/obo/WBPhenotype_0000985>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000985> (blast cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000985> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006783>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000986> (<http://purl.obolibrary.org/obo/WBPhenotype_0000986>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000986> (epithelial cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000986> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003672>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000987> (<http://purl.obolibrary.org/obo/WBPhenotype_0000987>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000987> (germ cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000987> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006796>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000989> (<http://purl.obolibrary.org/obo/WBPhenotype_0000989>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000989> (marginal cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000989> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003673>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000990> (<http://purl.obolibrary.org/obo/WBPhenotype_0000990>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000990> (muscle cell physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000990> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003675>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000991> (<http://purl.obolibrary.org/obo/WBPhenotype_0000991>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0000991> (neuron physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0000991> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003679>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001005> (<http://purl.obolibrary.org/obo/WBPhenotype_0001005>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001005> (backward locomotion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043057>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001009> (<http://purl.obolibrary.org/obo/WBPhenotype_0001009>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001009> (developmental pigmentation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001009> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048066>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001012> (<http://purl.obolibrary.org/obo/WBPhenotype_0001012>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001012> (organism pathogen response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0098542>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001015> (<http://purl.obolibrary.org/obo/WBPhenotype_0001015>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001015> (developmental growth variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048589>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001024> (<http://purl.obolibrary.org/obo/WBPhenotype_0001024>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001024> (male morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007850>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001025> (<http://purl.obolibrary.org/obo/WBPhenotype_0001025>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001025> (hermaphrodite morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007849>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001028> (<http://purl.obolibrary.org/obo/WBPhenotype_0001028>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001028> (nuclear appearance variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001028> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001031> (<http://purl.obolibrary.org/obo/WBPhenotype_0001031>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001031> (pronuclear migration reduced early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001032> (<http://purl.obolibrary.org/obo/WBPhenotype_0001032>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001032> (larval behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001032> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030537>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001042> (<http://purl.obolibrary.org/obo/WBPhenotype_0001042>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001042> (neuron function reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001048> (<http://purl.obolibrary.org/obo/WBPhenotype_0001048>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001048> (odorant chemosensory response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042048>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001049> (<http://purl.obolibrary.org/obo/WBPhenotype_0001049>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001049> (chemosensory behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007635>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001072> (<http://purl.obolibrary.org/obo/WBPhenotype_0001072>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001072> (response to food variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001072> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032094>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001075> (<http://purl.obolibrary.org/obo/WBPhenotype_0001075>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001075> (vulval muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001075> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005821>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001093> (<http://purl.obolibrary.org/obo/WBPhenotype_0001093>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001093> (intestinal physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001093> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005772>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001095> (<http://purl.obolibrary.org/obo/WBPhenotype_0001095>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001095> (organism high sodium chloride hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001095> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_26710>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001098> (<http://purl.obolibrary.org/obo/WBPhenotype_0001098>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001098> (no rectum)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001098> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005773>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001140> (<http://purl.obolibrary.org/obo/WBPhenotype_0001140>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001140> (neuron migration variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001764>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001168> (<http://purl.obolibrary.org/obo/WBPhenotype_0001168>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001168> (pseudocleavage absent early emb)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030590>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001172> (<http://purl.obolibrary.org/obo/WBPhenotype_0001172>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001172> (programmed cell death variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0012501>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001182> (<http://purl.obolibrary.org/obo/WBPhenotype_0001182>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001182> (fat content variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_18059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001183> (<http://purl.obolibrary.org/obo/WBPhenotype_0001183>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001183> (fat content reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_18059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001184> (<http://purl.obolibrary.org/obo/WBPhenotype_0001184>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001184> (fat content increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_18059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001190> (<http://purl.obolibrary.org/obo/WBPhenotype_0001190>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001190> (pharyngeal physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003681>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001191> (<http://purl.obolibrary.org/obo/WBPhenotype_0001191>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001191> (pharyngeal muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005451>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001192> (<http://purl.obolibrary.org/obo/WBPhenotype_0001192>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001192> (calcium signaling in pharynx variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0019722> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0003681>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001197> (<http://purl.obolibrary.org/obo/WBPhenotype_0001197>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001197> (somatic gonad physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005785>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001198> (<http://purl.obolibrary.org/obo/WBPhenotype_0001198>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001198> (somatic sheath physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001198> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005828>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001202> (<http://purl.obolibrary.org/obo/WBPhenotype_0001202>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001202> (nicotine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001202> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18723>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001203> (<http://purl.obolibrary.org/obo/WBPhenotype_0001203>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001203> (nicotine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001203> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18723>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001204> (<http://purl.obolibrary.org/obo/WBPhenotype_0001204>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001204> (muscimol resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001204> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_7035>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001205> (<http://purl.obolibrary.org/obo/WBPhenotype_0001205>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001205> (muscimol hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_7035>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (<http://purl.obolibrary.org/obo/WBPhenotype_0001210>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001210> (pericellular component physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005732>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001225> (<http://purl.obolibrary.org/obo/WBPhenotype_0001225>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001225> (phasmid socket absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008410>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001228> (<http://purl.obolibrary.org/obo/WBPhenotype_0001228>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001228> (alae absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001231> (<http://purl.obolibrary.org/obo/WBPhenotype_0001231>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001231> (intraflagellar transport accelerated)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001242> (<http://purl.obolibrary.org/obo/WBPhenotype_0001242>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001242> (intraflagellar transport slow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001244> (<http://purl.obolibrary.org/obo/WBPhenotype_0001244>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001244> (intraflagellar transport absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0042073>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001260> (<http://purl.obolibrary.org/obo/WBPhenotype_0001260>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001260> (oocyte morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001260> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006797>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001262> (<http://purl.obolibrary.org/obo/WBPhenotype_0001262>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001262> (vulval development incomplete)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040025>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001263> (<http://purl.obolibrary.org/obo/WBPhenotype_0001263>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001263> (peroxisome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001263> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005777>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001264> (<http://purl.obolibrary.org/obo/WBPhenotype_0001264>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001264> (peroxisome physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/GO_0005777>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001268> (<http://purl.obolibrary.org/obo/WBPhenotype_0001268>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001268> (induced cell death variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001268> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043068>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001273> (<http://purl.obolibrary.org/obo/WBPhenotype_0001273>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001273> (organism heat response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001273> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009408>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001283> (<http://purl.obolibrary.org/obo/WBPhenotype_0001283>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001283> (organelle metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001283> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008152> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/GO_0043226>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001289> (<http://purl.obolibrary.org/obo/WBPhenotype_0001289>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001289> (acetylcholinesterase inhibitor resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38462>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001291> (<http://purl.obolibrary.org/obo/WBPhenotype_0001291>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001291> (social behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035176>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001292> (<http://purl.obolibrary.org/obo/WBPhenotype_0001292>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001292> (body wall muscle physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006804>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001294> (<http://purl.obolibrary.org/obo/WBPhenotype_0001294>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001294> (head bent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001294> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001296> (<http://purl.obolibrary.org/obo/WBPhenotype_0001296>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001296> (lannate resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6835>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001301> (<http://purl.obolibrary.org/obo/WBPhenotype_0001301>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001301> (P granule abnormal)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001301> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043186>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001305> (<http://purl.obolibrary.org/obo/WBPhenotype_0001305>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001305> (hook morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001305> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008425>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001312> (<http://purl.obolibrary.org/obo/WBPhenotype_0001312>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001312> (neuron number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001313> (<http://purl.obolibrary.org/obo/WBPhenotype_0001313>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001313> (uterine muscle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001313> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005342>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001314> (<http://purl.obolibrary.org/obo/WBPhenotype_0001314>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001314> (vulval muscle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001314> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001323> (<http://purl.obolibrary.org/obo/WBPhenotype_0001323>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001323> (vesicle morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001323> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031982>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001324> (<http://purl.obolibrary.org/obo/WBPhenotype_0001324>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001324> (cell ionizing radiation response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0071479>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001326> (<http://purl.obolibrary.org/obo/WBPhenotype_0001326>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001326> (cell gamma ray response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0071480>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001330> (<http://purl.obolibrary.org/obo/WBPhenotype_0001330>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001330> (egg laying event infrequent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001330> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000911> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0018991>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001331> (<http://purl.obolibrary.org/obo/WBPhenotype_0001331>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001331> (motor neuron morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001331> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005409>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001332> (<http://purl.obolibrary.org/obo/WBPhenotype_0001332>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001332> (vesicle number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001332> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031982>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001338> (<http://purl.obolibrary.org/obo/WBPhenotype_0001338>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001338> (phentolamine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001338> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_8081>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001348> (<http://purl.obolibrary.org/obo/WBPhenotype_0001348>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001348> (chromosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001348> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005694>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001349> (<http://purl.obolibrary.org/obo/WBPhenotype_0001349>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001349> (protein phosphorylation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001349> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006468>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001352> (<http://purl.obolibrary.org/obo/WBPhenotype_0001352>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001352> (endoplasmic reticulum metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008152> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/GO_0005783>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001354> (<http://purl.obolibrary.org/obo/WBPhenotype_0001354>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001354> (actin cytoskeleton filament morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001354> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005884>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001355> (<http://purl.obolibrary.org/obo/WBPhenotype_0001355>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001355> (gonad morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001355> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005175>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001357> (<http://purl.obolibrary.org/obo/WBPhenotype_0001357>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001357> (male gonad morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001357> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006794>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001359> (<http://purl.obolibrary.org/obo/WBPhenotype_0001359>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001359> (proctodeum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006795>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001361> (<http://purl.obolibrary.org/obo/WBPhenotype_0001361>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001361> (chromosome condensation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001361> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030261>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001362> (<http://purl.obolibrary.org/obo/WBPhenotype_0001362>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001362> (chromosome condensation failure)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030261>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001367> (<http://purl.obolibrary.org/obo/WBPhenotype_0001367>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001367> (proctodeum development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006795>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001368> (<http://purl.obolibrary.org/obo/WBPhenotype_0001368>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001368> (spermatheca absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005319>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001369> (<http://purl.obolibrary.org/obo/WBPhenotype_0001369>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001369> (protein interaction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001369> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0065003>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001371> (<http://purl.obolibrary.org/obo/WBPhenotype_0001371>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001371> (protein RNA interaction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001371> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0022618>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001372> (<http://purl.obolibrary.org/obo/WBPhenotype_0001372>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001372> (protein DNA interaction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001372> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0065004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001373> (<http://purl.obolibrary.org/obo/WBPhenotype_0001373>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001373> (protein RNA interaction abolished)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001373> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0022618>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001378> (<http://purl.obolibrary.org/obo/WBPhenotype_0001378>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001378> (mitotic chromosome segregation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001378> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000070>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001379> (<http://purl.obolibrary.org/obo/WBPhenotype_0001379>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001379> (organism toxic chemical response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001379> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009636>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001382> (<http://purl.obolibrary.org/obo/WBPhenotype_0001382>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001382> (protein modification variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001382> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0036211>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001383> (<http://purl.obolibrary.org/obo/WBPhenotype_0001383>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001383> (protein methylation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001383> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006479>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001392> (<http://purl.obolibrary.org/obo/WBPhenotype_0001392>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001392> (cell cycle arrest)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007049>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001393> (<http://purl.obolibrary.org/obo/WBPhenotype_0001393>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001393> (cell acidification variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051452>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001396> (<http://purl.obolibrary.org/obo/WBPhenotype_0001396>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001396> (pumping absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001396> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001397> (<http://purl.obolibrary.org/obo/WBPhenotype_0001397>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001397> (necrotic cell death increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001397> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0070265>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001398> (<http://purl.obolibrary.org/obo/WBPhenotype_0001398>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001398> (neurite morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001398> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043005>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001399> (<http://purl.obolibrary.org/obo/WBPhenotype_0001399>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001399> (cell membrane morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001399> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005886>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001401> (<http://purl.obolibrary.org/obo/WBPhenotype_0001401>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001401> (mitochondria morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001401> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005739>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001412> (<http://purl.obolibrary.org/obo/WBPhenotype_0001412>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001412> (alae morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0007832>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001417> (<http://purl.obolibrary.org/obo/WBPhenotype_0001417>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001417> (organism desiccation response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009269>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001419> (<http://purl.obolibrary.org/obo/WBPhenotype_0001419>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001419> (emetine hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_4781>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001421> (<http://purl.obolibrary.org/obo/WBPhenotype_0001421>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001421> (endocytic transport variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006897>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001423> (<http://purl.obolibrary.org/obo/WBPhenotype_0001423>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001423> (coelomocyte physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005751>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001424> (<http://purl.obolibrary.org/obo/WBPhenotype_0001424>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001424> (oocyte physiology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001424> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006797>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001430> (<http://purl.obolibrary.org/obo/WBPhenotype_0001430>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001430> (lysosome organization biogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007040>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001434> (<http://purl.obolibrary.org/obo/WBPhenotype_0001434>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001434> (chemotaxis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001434> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006935>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001485> (<http://purl.obolibrary.org/obo/WBPhenotype_0001485>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001485> (ER stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001485> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034976>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001487> (<http://purl.obolibrary.org/obo/WBPhenotype_0001487>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001487> (male spicule development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001487> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005312>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001488> (<http://purl.obolibrary.org/obo/WBPhenotype_0001488>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001488> (gubernaculum development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001488> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0008424>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001489> (<http://purl.obolibrary.org/obo/WBPhenotype_0001489>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001489> (gubernaculum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001489> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008424>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001492> (<http://purl.obolibrary.org/obo/WBPhenotype_0001492>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001492> (no back end)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005741>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001499> (<http://purl.obolibrary.org/obo/WBPhenotype_0001499>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001499> (meiotic chromosome segregation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045132>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001502> (<http://purl.obolibrary.org/obo/WBPhenotype_0001502>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001502> (chemical resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_24431>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001509> (<http://purl.obolibrary.org/obo/WBPhenotype_0001509>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001509> (rays missing)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006941>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001514> (<http://purl.obolibrary.org/obo/WBPhenotype_0001514>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001514> (synaptic vesicle endocytosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001514> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048488>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001516> (<http://purl.obolibrary.org/obo/WBPhenotype_0001516>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001516> (helical cuticle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005755>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001517> (<http://purl.obolibrary.org/obo/WBPhenotype_0001517>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001517> (annulae morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0060107>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001523> (<http://purl.obolibrary.org/obo/WBPhenotype_0001523>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001523> (extracellular matrix variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031012>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001525> (<http://purl.obolibrary.org/obo/WBPhenotype_0001525>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001525> (terminal bulb morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001525> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001526> (<http://purl.obolibrary.org/obo/WBPhenotype_0001526>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001526> (ciliated neuron morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001526> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006816>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001530> (<http://purl.obolibrary.org/obo/WBPhenotype_0001530>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001530> (cephalic sensillum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001530> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006920>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001531> (<http://purl.obolibrary.org/obo/WBPhenotype_0001531>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001531> (labial sensillum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001531> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005107>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001532> (<http://purl.obolibrary.org/obo/WBPhenotype_0001532>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001532> (inner labial morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005116>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001533> (<http://purl.obolibrary.org/obo/WBPhenotype_0001533>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001533> (outer labial morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001533> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005501>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001535> (<http://purl.obolibrary.org/obo/WBPhenotype_0001535>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001535> (deirid sensillum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006926>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001539> (<http://purl.obolibrary.org/obo/WBPhenotype_0001539>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001539> (dauer induction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043053>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001567> (<http://purl.obolibrary.org/obo/WBPhenotype_0001567>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001567> (nuclei enlarged)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001568> (<http://purl.obolibrary.org/obo/WBPhenotype_0001568>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001568> (mRNA export variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001568> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006406>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001575> (<http://purl.obolibrary.org/obo/WBPhenotype_0001575>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001575> (ATP levels reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CHEBI_15422>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001578> (<http://purl.obolibrary.org/obo/WBPhenotype_0001578>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001578> (cholinergic agonist resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001578> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38324>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001579> (<http://purl.obolibrary.org/obo/WBPhenotype_0001579>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001579> (cholinergic agonist hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001579> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_38324>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001580> (<http://purl.obolibrary.org/obo/WBPhenotype_0001580>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001580> (nuclear envelope breakdown variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001580> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051081>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001584> (<http://purl.obolibrary.org/obo/WBPhenotype_0001584>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001584> (chromosome alignment variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051310>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001585> (<http://purl.obolibrary.org/obo/WBPhenotype_0001585>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001585> (asymmetric cell division variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008356>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001587> (<http://purl.obolibrary.org/obo/WBPhenotype_0001587>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001587> (actin organization biogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030036>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001588> (<http://purl.obolibrary.org/obo/WBPhenotype_0001588>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001588> (microtubule organization biogenesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001588> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000226>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001589> (<http://purl.obolibrary.org/obo/WBPhenotype_0001589>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001589> (microtubule nucleation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007020>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001590> (<http://purl.obolibrary.org/obo/WBPhenotype_0001590>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001590> (microtubule depolymerization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001590> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007019>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001591> (<http://purl.obolibrary.org/obo/WBPhenotype_0001591>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001591> (microtubule polymerization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001591> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0046785>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001597> (<http://purl.obolibrary.org/obo/WBPhenotype_0001597>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001597> (muscle missing)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001997> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003675>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001599> (<http://purl.obolibrary.org/obo/WBPhenotype_0001599>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001599> (ouabain resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_472805>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001602> (<http://purl.obolibrary.org/obo/WBPhenotype_0001602>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001602> (methiothepin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001602> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_64203>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001603> (<http://purl.obolibrary.org/obo/WBPhenotype_0001603>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001603> (cyproheptadine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001603> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_4046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001604> (<http://purl.obolibrary.org/obo/WBPhenotype_0001604>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001604> (mianserin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_51137>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001606> (<http://purl.obolibrary.org/obo/WBPhenotype_0001606>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001606> (ethanol hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_16236>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001608> (<http://purl.obolibrary.org/obo/WBPhenotype_0001608>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001608> (enflurane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_4792>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001609> (<http://purl.obolibrary.org/obo/WBPhenotype_0001609>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001609> (isoflurane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6015>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001610> (<http://purl.obolibrary.org/obo/WBPhenotype_0001610>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001610> (diethyl ether hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_35702>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001611> (<http://purl.obolibrary.org/obo/WBPhenotype_0001611>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001611> (halothane hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_5615>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001612> (<http://purl.obolibrary.org/obo/WBPhenotype_0001612>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001612> (ethanol resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_16236>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001615> (<http://purl.obolibrary.org/obo/WBPhenotype_0001615>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001615> (anticonvulsant resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001615> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_35623>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001616> (<http://purl.obolibrary.org/obo/WBPhenotype_0001616>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001616> (trimethadione resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_9727>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001617> (<http://purl.obolibrary.org/obo/WBPhenotype_0001617>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001617> (ethosuximide resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_4887>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001618> (<http://purl.obolibrary.org/obo/WBPhenotype_0001618>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001618> (halothane resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001618> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_5615>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001619> (<http://purl.obolibrary.org/obo/WBPhenotype_0001619>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001619> (isoflurane resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001619> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6015>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001620> (<http://purl.obolibrary.org/obo/WBPhenotype_0001620>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001620> (organism oxidative stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001620> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006979>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001630> (<http://purl.obolibrary.org/obo/WBPhenotype_0001630>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001630> (gut obstructed)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001819> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001635> (<http://purl.obolibrary.org/obo/WBPhenotype_0001635>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001635> (excess pharyngeal cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005460>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001636> (<http://purl.obolibrary.org/obo/WBPhenotype_0001636>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001636> (excess intestinal cells)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001636> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005792>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001637> (<http://purl.obolibrary.org/obo/WBPhenotype_0001637>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001637> (no Intestine)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001637> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005772>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001644> (<http://purl.obolibrary.org/obo/WBPhenotype_0001644>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001644> (protein metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0019538>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001645> (<http://purl.obolibrary.org/obo/WBPhenotype_0001645>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001645> (protein degradation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001645> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030163>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001646> (<http://purl.obolibrary.org/obo/WBPhenotype_0001646>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001646> (no pharynx)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003681>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001649> (<http://purl.obolibrary.org/obo/WBPhenotype_0001649>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001649> (Fluorouracil resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_46345>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001654> (<http://purl.obolibrary.org/obo/WBPhenotype_0001654>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001654> (cadmium resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001654> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_22977>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001655> (<http://purl.obolibrary.org/obo/WBPhenotype_0001655>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001655> (cadmium hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_22977>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001656> (<http://purl.obolibrary.org/obo/WBPhenotype_0001656>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001656> (distal tip cell development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0006865>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001657> (<http://purl.obolibrary.org/obo/WBPhenotype_0001657>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001657> (cell junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030054>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001658> (<http://purl.obolibrary.org/obo/WBPhenotype_0001658>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001658> (intercellular junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005911>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001659> (<http://purl.obolibrary.org/obo/WBPhenotype_0001659>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001659> (spermatheca morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001659> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005319>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001662> (<http://purl.obolibrary.org/obo/WBPhenotype_0001662>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001662> (spermatheca development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001662> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0005319>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001667> (<http://purl.obolibrary.org/obo/WBPhenotype_0001667>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001667> (methyl methanesulfonate hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001667> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25255>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001669> (<http://purl.obolibrary.org/obo/WBPhenotype_0001669>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001669> (presynaptic vesicle number variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001669> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008021>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001671> (<http://purl.obolibrary.org/obo/WBPhenotype_0001671>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001671> (vesicle organization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016050>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001674> (<http://purl.obolibrary.org/obo/WBPhenotype_0001674>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001674> (telomere morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001674> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000781>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001675> (<http://purl.obolibrary.org/obo/WBPhenotype_0001675>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001675> (male gonad development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001675> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0006794>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001676> (<http://purl.obolibrary.org/obo/WBPhenotype_0001676>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001676> (touch receptor cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001676> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005237>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001695> (<http://purl.obolibrary.org/obo/WBPhenotype_0001695>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001695> (glycosyltransferase activity variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001695> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016757>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001696> (<http://purl.obolibrary.org/obo/WBPhenotype_0001696>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001696> (biosynthesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001696> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009058>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001711> (<http://purl.obolibrary.org/obo/WBPhenotype_0001711>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001711> (rhythmic behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001711> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007622>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001712> (<http://purl.obolibrary.org/obo/WBPhenotype_0001712>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001712> (circadian rhythm behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001712> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0048512>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001719> (<http://purl.obolibrary.org/obo/WBPhenotype_0001719>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001719> (unfolded protein response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001719> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006986>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001724> (<http://purl.obolibrary.org/obo/WBPhenotype_0001724>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001724> (tunicamycin hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001724> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_29699>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001725> (<http://purl.obolibrary.org/obo/WBPhenotype_0001725>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001725> (cellular osmotic stress response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001725> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0071470>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001732> (<http://purl.obolibrary.org/obo/WBPhenotype_0001732>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001732> (organism response to pH variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001732> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009268>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001739> (<http://purl.obolibrary.org/obo/WBPhenotype_0001739>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001739> (aging variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001739> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007568>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001740> (<http://purl.obolibrary.org/obo/WBPhenotype_0001740>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001740> (organ senescence variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001740> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010260>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001742> (<http://purl.obolibrary.org/obo/WBPhenotype_0001742>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001742> (lipid synthesis increased)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001742> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008610>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001743> (<http://purl.obolibrary.org/obo/WBPhenotype_0001743>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001743> (mitosis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001743> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1903047>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001744> (<http://purl.obolibrary.org/obo/WBPhenotype_0001744>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001744> (cell adhesion variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001744> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007155>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001745> (<http://purl.obolibrary.org/obo/WBPhenotype_0001745>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001745> (adherens junction variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001745> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005912>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001746> (<http://purl.obolibrary.org/obo/WBPhenotype_0001746>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001746> (tight junction defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001746> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0070160>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001749> (<http://purl.obolibrary.org/obo/WBPhenotype_0001749>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001749> (zinc toxicity hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001749> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27363>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001750> (<http://purl.obolibrary.org/obo/WBPhenotype_0001750>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001750> (zinc toxicity resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27363>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001752> (<http://purl.obolibrary.org/obo/WBPhenotype_0001752>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001752> (vesicle trafficking variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001752> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016192>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001764> (<http://purl.obolibrary.org/obo/WBPhenotype_0001764>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001764> (carbon dioxide response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001764> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010037>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001780> (<http://purl.obolibrary.org/obo/WBPhenotype_0001780>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001780> (associative learning variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0008306>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001781> (<http://purl.obolibrary.org/obo/WBPhenotype_0001781>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001781> (hypersensitivity to mutagen)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001781> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25435>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001788> (<http://purl.obolibrary.org/obo/WBPhenotype_0001788>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001788> (resistant to mutagens)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001788> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25435>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001792> (<http://purl.obolibrary.org/obo/WBPhenotype_0001792>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001792> (nuclei small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001794> (<http://purl.obolibrary.org/obo/WBPhenotype_0001794>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001794> (cytoplasmic processing body variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000932>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001799> (<http://purl.obolibrary.org/obo/WBPhenotype_0001799>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001799> (inhibition of synaptogenesis hyperactive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001799> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000912> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051964>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001806> (<http://purl.obolibrary.org/obo/WBPhenotype_0001806>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001806> (protein stabilization variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001806> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0050821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001826> (<http://purl.obolibrary.org/obo/WBPhenotype_0001826>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001826> (RNA degradation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0006401>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001827> (<http://purl.obolibrary.org/obo/WBPhenotype_0001827>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001827> (RNA metabolism variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001827> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016070>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001832> (<http://purl.obolibrary.org/obo/WBPhenotype_0001832>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001832> (nuclear pore variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001832> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/GO_0005643>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001834> (<http://purl.obolibrary.org/obo/WBPhenotype_0001834>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001834> (mRNA splicing variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000398>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001836> (<http://purl.obolibrary.org/obo/WBPhenotype_0001836>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001836> (eggshell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001836> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005843>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001839> (<http://purl.obolibrary.org/obo/WBPhenotype_0001839>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001839> (phorbol ester resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_37532>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001840> (<http://purl.obolibrary.org/obo/WBPhenotype_0001840>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001840> (response to injury variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001840> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009611>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001854> (<http://purl.obolibrary.org/obo/WBPhenotype_0001854>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001854> (benomyl response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001854> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1901561>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001855> (<http://purl.obolibrary.org/obo/WBPhenotype_0001855>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001855> (fluoride resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001855> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_17051>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001863> (<http://purl.obolibrary.org/obo/WBPhenotype_0001863>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001863> (manganese response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001863> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010042>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001868> (<http://purl.obolibrary.org/obo/WBPhenotype_0001868>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001868> (meiotic spindle defective)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001868> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0072687>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001877> (<http://purl.obolibrary.org/obo/WBPhenotype_0001877>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001877> (nuclear membrane morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001877> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0031965>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001878> (<http://purl.obolibrary.org/obo/WBPhenotype_0001878>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001878> (hydroxyurea response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0072710>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001879> (<http://purl.obolibrary.org/obo/WBPhenotype_0001879>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001879> (hydroxyurea hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001879> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_44423>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001880> (<http://purl.obolibrary.org/obo/WBPhenotype_0001880>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001880> (endoplasmic reticulum morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001880> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005783>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001897> (<http://purl.obolibrary.org/obo/WBPhenotype_0001897>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001897> (light response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001897> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0009416>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001904> (<http://purl.obolibrary.org/obo/WBPhenotype_0001904>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001904> (manganese toxicity resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001904> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18291>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001918> (<http://purl.obolibrary.org/obo/WBPhenotype_0001918>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001918> (chemical hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001918> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_24431>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001929> (<http://purl.obolibrary.org/obo/WBPhenotype_0001929>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001929> (linker cell absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001929> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005062>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001945> (<http://purl.obolibrary.org/obo/WBPhenotype_0001945>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001945> (oocytes small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001945> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006797>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001957> (<http://purl.obolibrary.org/obo/WBPhenotype_0001957>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001957> (gonad small)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001957> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005175>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001988> (<http://purl.obolibrary.org/obo/WBPhenotype_0001988>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0001988> (detergent hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0001988> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27780>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002031> (<http://purl.obolibrary.org/obo/WBPhenotype_0002031>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002031> (lectin response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_1990840>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002048> (<http://purl.obolibrary.org/obo/WBPhenotype_0002048>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002048> (abamectin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_39214>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002050> (<http://purl.obolibrary.org/obo/WBPhenotype_0002050>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002050> (abamectin sensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_39214>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002053> (<http://purl.obolibrary.org/obo/WBPhenotype_0002053>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002053> (ivermectin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_6078>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002054> (<http://purl.obolibrary.org/obo/WBPhenotype_0002054>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002054> (magnesium hypersensitivity)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25107>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002058> (<http://purl.obolibrary.org/obo/WBPhenotype_0002058>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002058> (pore forming toxin response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0035915>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002077> (<http://purl.obolibrary.org/obo/WBPhenotype_0002077>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002077> (dopamine resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18243>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002087> (<http://purl.obolibrary.org/obo/WBPhenotype_0002087>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002087> (hydrogen sulfide hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002087> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_16136>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002089> (<http://purl.obolibrary.org/obo/WBPhenotype_0002089>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002089> (cell component morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005575>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002090> (<http://purl.obolibrary.org/obo/WBPhenotype_0002090>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002090> (endosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002090> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005768>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002091> (<http://purl.obolibrary.org/obo/WBPhenotype_0002091>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002091> (late endosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002091> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005770>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002092> (<http://purl.obolibrary.org/obo/WBPhenotype_0002092>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002092> (early endosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002092> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005769>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002093> (<http://purl.obolibrary.org/obo/WBPhenotype_0002093>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002093> (recycling endosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002093> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0055037>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002096> (<http://purl.obolibrary.org/obo/WBPhenotype_0002096>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002096> (golgi apparatus morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002096> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005794>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002097> (<http://purl.obolibrary.org/obo/WBPhenotype_0002097>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002097> (lysosome morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002097> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005764>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002136> (<http://purl.obolibrary.org/obo/WBPhenotype_0002136>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002136> (no anchor cell)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004522>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002139> (<http://purl.obolibrary.org/obo/WBPhenotype_0002139>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002139> (linker cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002139> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005062>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002164> (<http://purl.obolibrary.org/obo/WBPhenotype_0002164>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002164> (innate immune response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0045087>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002176> (<http://purl.obolibrary.org/obo/WBPhenotype_0002176>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002176> (seam cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005753>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002205> (<http://purl.obolibrary.org/obo/WBPhenotype_0002205>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002205> (hypersensitive to galactose)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28260>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002209> (<http://purl.obolibrary.org/obo/WBPhenotype_0002209>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002209> (hook development variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0008150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002295> <http://purl.obolibrary.org/obo/WBbt_0008425>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002217> (<http://purl.obolibrary.org/obo/WBPhenotype_0002217>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002217> (antimony hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002217> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_30513>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002218> (<http://purl.obolibrary.org/obo/WBPhenotype_0002218>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002218> (arsenite hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002218> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_22633>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002219> (<http://purl.obolibrary.org/obo/WBPhenotype_0002219>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002219> (fluoranthene hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002219> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_33083>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002220> (<http://purl.obolibrary.org/obo/WBPhenotype_0002220>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002220> (antimonite hypersensitivity)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002220> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_30297>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002223> (<http://purl.obolibrary.org/obo/WBPhenotype_0002223>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002223> (manganese hypersensitivity)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18291>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002224> (<http://purl.obolibrary.org/obo/WBPhenotype_0002224>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002224> (mercury hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002224> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25195>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002225> (<http://purl.obolibrary.org/obo/WBPhenotype_0002225>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002225> (lead hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_25016>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002226> (<http://purl.obolibrary.org/obo/WBPhenotype_0002226>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002226> (cobalt hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27638>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002227> (<http://purl.obolibrary.org/obo/WBPhenotype_0002227>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002227> (lead response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010288>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002228> (<http://purl.obolibrary.org/obo/WBPhenotype_0002228>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002228> (aluminum response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010044>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002240> (<http://purl.obolibrary.org/obo/WBPhenotype_0002240>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002240> (gut granule morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0044840>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002244> (<http://purl.obolibrary.org/obo/WBPhenotype_0002244>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002244> (arsenic hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_27563>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002250> (<http://purl.obolibrary.org/obo/WBPhenotype_0002250>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002250> (silver hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_30512>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002251> (<http://purl.obolibrary.org/obo/WBPhenotype_0002251>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002251> (silver nanoparticle hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_50826>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002256> (<http://purl.obolibrary.org/obo/WBPhenotype_0002256>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002256> (selenium response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0010269>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002257> (<http://purl.obolibrary.org/obo/WBPhenotype_0002257>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002257> (iron hypersensitive)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_18248>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002258> (<http://purl.obolibrary.org/obo/WBPhenotype_0002258>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002258> (nickel toxicity resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_28112>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002408> (<http://purl.obolibrary.org/obo/WBPhenotype_0002408>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002408> (cytokinesis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002408> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0000910>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002414> (<http://purl.obolibrary.org/obo/WBPhenotype_0002414>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002414> (spindle variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0007051>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002416> (<http://purl.obolibrary.org/obo/WBPhenotype_0002416>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002416> (spindle position variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002416> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051293>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002417> (<http://purl.obolibrary.org/obo/WBPhenotype_0002417>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002417> (spindle rotation variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0051294>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002418> (<http://purl.obolibrary.org/obo/WBPhenotype_0002418>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002418> (spindle absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0005819>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002422> (<http://purl.obolibrary.org/obo/WBPhenotype_0002422>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002422> (tunicamycin resistant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/CARO_0010004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002503> <http://purl.obolibrary.org/obo/CHEBI_29699>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002423> (<http://purl.obolibrary.org/obo/WBPhenotype_0002423>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002423> (hypoxia response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0001666>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002424> (<http://purl.obolibrary.org/obo/WBPhenotype_0002424>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002424> (anoxia response variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002424> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034059>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002463> (<http://purl.obolibrary.org/obo/WBPhenotype_0002463>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002463> (hookless)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0008425>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002485> (<http://purl.obolibrary.org/obo/WBPhenotype_0002485>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002485> (germline precursor cell morphology variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002485> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006849>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002490> (<http://purl.obolibrary.org/obo/WBPhenotype_0002490>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002490> (ectopic axon outgrowth)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030424>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002491> (<http://purl.obolibrary.org/obo/WBPhenotype_0002491>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002491> (ectopic neurite outgrowth)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002491> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043005>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002492> (<http://purl.obolibrary.org/obo/WBPhenotype_0002492>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002492> (ectopic body wall muscle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006804>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002493> (<http://purl.obolibrary.org/obo/WBPhenotype_0002493>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002493> (ectopic cell)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0004017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002495> (<http://purl.obolibrary.org/obo/WBPhenotype_0002495>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002495> (ectopic hypodermis)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005733>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002496> (<http://purl.obolibrary.org/obo/WBPhenotype_0002496>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002496> (ectopic neuron)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003679>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002497> (<http://purl.obolibrary.org/obo/WBPhenotype_0002497>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002497> (ectopic pharyngeal muscle)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0005451>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002498> (<http://purl.obolibrary.org/obo/WBPhenotype_0002498>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002498> (ectopic organ)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0003760>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002499> (<http://purl.obolibrary.org/obo/WBPhenotype_0002499>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002499> (ectopic vulva)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/WBbt_0006748>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002500> (<http://purl.obolibrary.org/obo/WBPhenotype_0002500>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002500> (ectopic cleavage furrow)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0032154>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002512> (<http://purl.obolibrary.org/obo/WBPhenotype_0002512>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002512> (thermosensory behavior variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002512> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0040040>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002513> (<http://purl.obolibrary.org/obo/WBPhenotype_0002513>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002513> (thermotaxis variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043052>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002514> (<http://purl.obolibrary.org/obo/WBPhenotype_0002514>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002514> (backing absent)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002514> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0043057>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002519> (<http://purl.obolibrary.org/obo/WBPhenotype_0002519>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002519> (axon length reduced)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0030424>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002538> (<http://purl.obolibrary.org/obo/WBPhenotype_0002538>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002538> (calcium signaling in spermatheca variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002538> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0019722> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/WBbt_0005319>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002551> (<http://purl.obolibrary.org/obo/WBPhenotype_0002551>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002551> (anatomical phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0000100>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002552> (<http://purl.obolibrary.org/obo/WBPhenotype_0002552>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002552> (cell phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0004017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002553> (<http://purl.obolibrary.org/obo/WBPhenotype_0002553>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002553> (organ phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0003760>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002554> (<http://purl.obolibrary.org/obo/WBPhenotype_0002554>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002554> (organ system phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002554> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005746>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002555> (<http://purl.obolibrary.org/obo/WBPhenotype_0002555>)
-
-EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0007833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
-
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002556> (<http://purl.obolibrary.org/obo/WBPhenotype_0002556>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002556> (tissue phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002556> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005729>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002557> (<http://purl.obolibrary.org/obo/WBPhenotype_0002557>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002557> (body region phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005738>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002558> (<http://purl.obolibrary.org/obo/WBPhenotype_0002558>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0002558> (extracellular component phenotype)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0002558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> <http://purl.obolibrary.org/obo/WBbt_0005732>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004030> (<http://purl.obolibrary.org/obo/WBPhenotype_0004030>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0004030> (male response to hermaphrodite variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0004030> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0034606>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 
-# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0010001> (<http://purl.obolibrary.org/obo/WBPhenotype_0010001>)
+# Class: <http://purl.obolibrary.org/obo/WBPhenotype_0010001> (cell growth variant)
 
 EquivalentClasses(<http://purl.obolibrary.org/obo/WBPhenotype_0010001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/GO_0016049>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
 


### PR DESCRIPTION
Changing primary labels from 'variant' to 'phenotype', including root node 'Variant' label to 'nematode phenotype';
Obsoleted 'organismal phenotype'